### PR TITLE
fix : [009-CUSTOMER-CONFIRM-PRODUCT] 고객 서비스요청서에 따른 제안된 상품목록 조회

### DIFF
--- a/shop/build.gradle
+++ b/shop/build.gradle
@@ -40,6 +40,12 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-validation
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.2'
+
+	//queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 tasks.named('test') {

--- a/shop/src/main/java/com/moving/shop/common/config/QueryDslConfig.java
+++ b/shop/src/main/java/com/moving/shop/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.moving.shop.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/shop/src/main/java/com/moving/shop/company/domain/dto/CompanyInformationForm.java
+++ b/shop/src/main/java/com/moving/shop/company/domain/dto/CompanyInformationForm.java
@@ -1,0 +1,40 @@
+package com.moving.shop.company.domain.dto;
+
+import com.moving.shop.company.domain.entity.Company;
+import com.moving.shop.customer.domain.type.ServiceCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyInformationForm {
+
+  /* 가입 이메일 */
+  private String email;
+
+  /* 서비스카테고리 */
+  private ServiceCategory serviceCategory;
+
+  /* 업체 주소 */
+  private String address;
+
+  /* 업체 연락처 */
+  private String tel;
+
+  /* 업체 소개글 */
+  private String introduction;
+
+  public static CompanyInformationForm from(Company company) {
+    return CompanyInformationForm.builder()
+        .serviceCategory(company.getServiceCategory())
+        .email(company.getEmail())
+        .address(company.getAddress())
+        .tel(company.getTel())
+        .introduction(company.getIntroduction())
+        .build();
+  }
+}

--- a/shop/src/main/java/com/moving/shop/product/controller/CustomerProductController.java
+++ b/shop/src/main/java/com/moving/shop/product/controller/CustomerProductController.java
@@ -3,6 +3,7 @@ package com.moving.shop.product.controller;
 import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_HEADER;
 import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_PREFIX;
 
+import com.moving.shop.product.domain.dto.ProposedProductResponse;
 import com.moving.shop.product.service.CustomerProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class CustomerProductController {
   public ResponseEntity<?> showReceivedServiceProduct(@RequestHeader(value = TOKEN_HEADER) String token) {
 
     String refinedToken = token.substring(TOKEN_PREFIX.length());
-    return ResponseEntity.ok(customerProductService.findByCustomerId(refinedToken));
+    return ResponseEntity.ok(ProposedProductResponse.from(customerProductService.findByCustomerId(refinedToken)));
   }
 
 }

--- a/shop/src/main/java/com/moving/shop/product/controller/CustomerProductController.java
+++ b/shop/src/main/java/com/moving/shop/product/controller/CustomerProductController.java
@@ -1,0 +1,30 @@
+package com.moving.shop.product.controller;
+
+import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_HEADER;
+import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_PREFIX;
+
+import com.moving.shop.product.service.CustomerProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/customer/service-product")
+@RequiredArgsConstructor
+public class CustomerProductController {
+
+  private final CustomerProductService customerProductService;
+
+  @GetMapping
+  @PreAuthorize("hasAuthority('CUSTOMER')")
+  public ResponseEntity<?> showReceivedServiceProduct(@RequestHeader(value = TOKEN_HEADER) String token) {
+
+    String refinedToken = token.substring(TOKEN_PREFIX.length());
+    return ResponseEntity.ok(customerProductService.findByCustomerId(refinedToken));
+  }
+
+}

--- a/shop/src/main/java/com/moving/shop/product/domain/dto/ProposedProductResponse.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/dto/ProposedProductResponse.java
@@ -1,0 +1,52 @@
+package com.moving.shop.product.domain.dto;
+
+import com.moving.shop.company.domain.dto.CompanyInformationForm;
+import com.moving.shop.company.domain.entity.Company;
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProposedProductResponse {
+
+  /* 서비스상품명 */
+  private String name;
+
+  /* 상품개요설명 */
+  private String outlineDescription;
+
+  /* 상품 금액 */
+  private int productPrice;
+
+  /* 서비스 실행일시 */
+  private LocalDateTime executeDate;
+
+  /* 고객 서비스 요청서 ID */
+  private Long serviceRequestId;
+
+  private CompanyInformationForm companyInfo;
+
+  public static List<ProposedProductResponse> from(List<ServiceProduct> serviceProducts) {
+
+    return serviceProducts.stream().map(serviceProduct -> from(serviceProduct))
+        .collect(Collectors.toList());
+  }
+
+  private static ProposedProductResponse from(ServiceProduct serviceProduct) {
+    return ProposedProductResponse.builder()
+        .name(serviceProduct.getName())
+        .outlineDescription(serviceProduct.getOutlineDescription())
+        .productPrice(serviceProduct.getProductPrice())
+        .executeDate(serviceProduct.getExecuteDate())
+        .companyInfo(CompanyInformationForm.from(serviceProduct.getCompany()))
+        .build();
+  }
+}

--- a/shop/src/main/java/com/moving/shop/product/domain/dto/ProposedProductResponse.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/dto/ProposedProductResponse.java
@@ -17,6 +17,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProposedProductResponse {
 
+  /* 서비스상품 id */
+  private Long id;
+
   /* 서비스상품명 */
   private String name;
 
@@ -42,6 +45,7 @@ public class ProposedProductResponse {
 
   private static ProposedProductResponse from(ServiceProduct serviceProduct) {
     return ProposedProductResponse.builder()
+        .id(serviceProduct.getId())
         .name(serviceProduct.getName())
         .outlineDescription(serviceProduct.getOutlineDescription())
         .productPrice(serviceProduct.getProductPrice())

--- a/shop/src/main/java/com/moving/shop/product/domain/dto/ServiceProductResponse.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/dto/ServiceProductResponse.java
@@ -42,7 +42,7 @@ public class ServiceProductResponse {
         .outlineDescription(serviceProduct.getOutlineDescription())
         .productPrice(serviceProduct.getProductPrice())
         .executeDate(serviceProduct.getExecuteDate())
-        .serviceRequestId(serviceProduct.getServiceRequestId())
+        .serviceRequestId(serviceProduct.getCustomerRequest().getId())
         .build();
   }
 

--- a/shop/src/main/java/com/moving/shop/product/domain/entity/ProductOption.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/entity/ProductOption.java
@@ -30,7 +30,7 @@ public class ProductOption extends BaseEntity {
 
   /* 서비스상품 ID */
   @ManyToOne
-  @JoinColumn(name = "serviceProductId")
+  @JoinColumn(name = "service_product_id")
   private ServiceProduct serviceProduct;
 
   /* 상품옵션명 */

--- a/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
@@ -1,5 +1,6 @@
 package com.moving.shop.product.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.company.domain.entity.Company;
 import com.moving.shop.customer.domain.entity.CustomerRequest;
@@ -38,12 +39,13 @@ public class ServiceProduct extends BaseEntity {
 
   /* 업체 ID */
   @ManyToOne
-  @JoinColumn(name = "companyId")
+  @JoinColumn(name = "company_id")
   private Company company;
 
   /* 서비스상품_옵션 */
+  @JsonIgnore
   @OneToMany(cascade = CascadeType.ALL)
-  @JoinColumn(name = "serviceProductId")
+  @JoinColumn(name = "service_product_id")
   private List<ProductOption> productOptions = new ArrayList<>();
 
   /* 서비스상품명 */
@@ -61,7 +63,7 @@ public class ServiceProduct extends BaseEntity {
   /* 고객 서비스 요청서 */
 //  private Long serviceRequestId;
   @ManyToOne
-  @JoinColumn(name = "customerRequestId")
+  @JoinColumn(name = "customer_request_id")
   private CustomerRequest customerRequest;
 
   /* 해당 서비스 상품 주문 여부 */

--- a/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
@@ -2,6 +2,7 @@ package com.moving.shop.product.domain.entity;
 
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.company.domain.entity.Company;
+import com.moving.shop.customer.domain.entity.CustomerRequest;
 import com.moving.shop.product.domain.dto.AddServiceProductForm;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -57,13 +58,16 @@ public class ServiceProduct extends BaseEntity {
   /* 서비스 실행일시 */
   private LocalDateTime executeDate;
 
-  /* 고객 서비스 요청서 ID */
-  private Long serviceRequestId;
+  /* 고객 서비스 요청서 */
+//  private Long serviceRequestId;
+  @ManyToOne
+  @JoinColumn(name = "customerRequestId")
+  private CustomerRequest customerRequest;
 
   /* 해당 서비스 상품 주문 여부 */
   private boolean purchaseYn;
 
-  public static ServiceProduct of(Company company, AddServiceProductForm form) {
+  public static ServiceProduct of(Company company, AddServiceProductForm form, CustomerRequest customerRequest) {
     return ServiceProduct.builder()
         .company(company)
         .productOptions(
@@ -74,7 +78,8 @@ public class ServiceProduct extends BaseEntity {
         .outlineDescription(form.getOutlineDescription())
         .productPrice(form.getProductPrice())
         .executeDate(form.getExecuteDate())
-        .serviceRequestId(form.getServiceRequestId())
+//        .serviceRequestId(form.getServiceRequestId())
+        .customerRequest(customerRequest)
         .purchaseYn(false)
         .build();
   }

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepository.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepository.java
@@ -3,6 +3,6 @@ package com.moving.shop.product.domain.repository;
 import com.moving.shop.product.domain.entity.ServiceProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ServiceProductRepository extends JpaRepository<ServiceProduct, Long> {
+public interface ServiceProductRepository extends JpaRepository<ServiceProduct, Long>, ServiceProductRepositoryCustom {
 
 }

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustom.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.moving.shop.product.domain.repository;
+
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import java.util.List;
+
+public interface ServiceProductRepositoryCustom {
+
+  List<ServiceProduct> findByCustomerId(Long customerId);
+
+}

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package com.moving.shop.product.domain.repository;
+
+import com.moving.shop.customer.domain.entity.QCustomerRequest;
+import com.moving.shop.product.domain.entity.QServiceProduct;
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ServiceProductRepositoryCustomImpl implements ServiceProductRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<ServiceProduct> findByCustomerId(Long customerId) {
+
+    QServiceProduct serviceProduct = QServiceProduct.serviceProduct;
+    QCustomerRequest customerRequest = QCustomerRequest.customerRequest;
+
+    return jpaQueryFactory.selectFrom(serviceProduct)
+        .innerJoin(serviceProduct.customerRequest, customerRequest).fetchJoin()
+        .where(customerRequest.customer.id.eq(customerId))
+        .fetch();
+  }
+}

--- a/shop/src/main/java/com/moving/shop/product/service/CustomerProductService.java
+++ b/shop/src/main/java/com/moving/shop/product/service/CustomerProductService.java
@@ -1,0 +1,9 @@
+package com.moving.shop.product.service;
+
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import java.util.List;
+
+public interface CustomerProductService {
+
+  List<ServiceProduct> findByCustomerId(String refinedToken);
+}

--- a/shop/src/main/java/com/moving/shop/product/service/impl/CompanyProductServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/service/impl/CompanyProductServiceImpl.java
@@ -5,6 +5,7 @@ import com.moving.shop.common.exception.type.CompanyErrorCode;
 import com.moving.shop.common.security.TokenProvider;
 import com.moving.shop.company.domain.entity.Company;
 import com.moving.shop.company.domain.repository.CompanyRepository;
+import com.moving.shop.customer.domain.entity.CustomerRequest;
 import com.moving.shop.customer.domain.repository.CustomerRequestRepository;
 import com.moving.shop.product.domain.dto.AddServiceProductForm;
 import com.moving.shop.product.domain.entity.ServiceProduct;
@@ -30,11 +31,14 @@ public class CompanyProductServiceImpl implements CompanyProductService {
         .orElseThrow(() -> new CompanyException(CompanyErrorCode.NOT_EXIST_COMPANY_MEMBER));
 
     //상품 등록 시에 참조할 고객요청서가 필요한 것으로 기획했기에 고객서비스요청서ID 존재여부 확인
-    boolean isValidRequest = customerRequestRepository.existsById(form.getServiceRequestId());
-    if (!isValidRequest) {
-      throw new CompanyException(CompanyErrorCode.SERVICE_REQUEST_NOT_EXIST);
-    }
+//    boolean isValidRequest = customerRequestRepository.existsById(form.getServiceRequestId());
+//    if (!isValidRequest) {
+//      throw new CompanyException(CompanyErrorCode.SERVICE_REQUEST_NOT_EXIST);
+//    }
+    //erd 수정으로 인한 코드 수정 (연관관계 수정)
+    CustomerRequest customerRequest = customerRequestRepository.findById(form.getServiceRequestId())
+        .orElseThrow(() -> new CompanyException(CompanyErrorCode.SERVICE_REQUEST_NOT_EXIST));
 
-    return serviceProductRepository.save(ServiceProduct.of(company, form));
+    return serviceProductRepository.save(ServiceProduct.of(company, form, customerRequest));
   }
 }

--- a/shop/src/main/java/com/moving/shop/product/service/impl/CustomerProductServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/service/impl/CustomerProductServiceImpl.java
@@ -1,0 +1,32 @@
+package com.moving.shop.product.service.impl;
+
+import com.moving.shop.common.exception.customexception.CustomerException;
+import com.moving.shop.common.exception.type.CustomerErrorCode;
+import com.moving.shop.common.security.TokenProvider;
+import com.moving.shop.customer.domain.entity.Customer;
+import com.moving.shop.customer.domain.repository.CustomerRepository;
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import com.moving.shop.product.domain.repository.ServiceProductRepository;
+import com.moving.shop.product.service.CustomerProductService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerProductServiceImpl implements CustomerProductService {
+
+  private final TokenProvider tokenProvider;
+  private final CustomerRepository customerRepository;
+  private final ServiceProductRepository serviceProductRepository;
+
+  @Override
+  public List<ServiceProduct> findByCustomerId(String refinedToken) {
+
+    String email = tokenProvider.getUsername(refinedToken);
+    Customer customer = customerRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_EXIST_MEMBER));
+
+    return serviceProductRepository.findByCustomerId(customer.getId());
+  }
+}

--- a/shop/src/main/resources/application.properties
+++ b/shop/src/main/resources/application.properties
@@ -10,7 +10,12 @@ spring.datasource.password=1
 
 #spring.jpa.database=mysql
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=update
+
+# show sql data binding
+logging.level.org.hibernate.SQL = debug
+logging.level.org.hibernate.type.descriptor.sql = trace
 
 #spring.redis.host=localhost
 #spring.redis.port=6379

--- a/shop/src/test/java/com/moving/shop/product/service/CompanyProductServiceTest.java
+++ b/shop/src/test/java/com/moving/shop/product/service/CompanyProductServiceTest.java
@@ -91,6 +91,8 @@ class CompanyProductServiceTest {
     //then
     assertNotNull(serviceProduct);
     assertEquals(serviceProduct.getProductPrice(), addServiceProductForm.getProductPrice());
+    assertNotNull(serviceProduct.getProductOptions());
+    assertEquals(serviceProduct.getProductOptions().size(), 2);
   }
 
   @Test


### PR DESCRIPTION
:white_check_mark: Changes

- 고객이 본인의 서비스 요청서에 대해 업체로부터 받은 서비스상품 제안 목록을 조회하는 API를 추가하였습니다.
- 화면단에서 사용할 data들을 고려해서 response 값을 구성해보았습니다. (필요한 값들만 잘 정리하기)
- 다수의 table 조회 시, join해서 얻어와야 할 값은 queryDSL을 통해서 조회하는 것으로 하였습니다.

<br>

:heavy_plus_sign: Related Details

- API마다 각각 맞는 request와 respone class를 생성하는 것으로 프로젝트 내 규칙을 세웠기 떄문에 이를 준수하기 위해 기존의 response dto에 컬럼을 추가하기 보단 해당 API에 맞는 새 dto response를 만들어서 조회결과값을 세팅하였습니다. 
-queryDSL의 경우, 우선 db tool에서 native 쿼리를 작성해보고 이에 맞게끔 쿼리가 생성될 수 있게 queryDSL 문법을 적용해보는 식으로 구현하였습니다.

<br>

:pray: Reference
- queryDSL의 개념 학습에 참고한 블로그 포스팅 : https://cs-ssupport.tistory.com/516
- 해당 API에서 트러블 해결 시 참고한 블로그 포스팅: https://doingsomething.tistory.com/75?category=1041322