### PR TITLE
feat: [010-CUSTOMER-ORDER] 주문 기능 test 추가 및 JPA라인 추가

### DIFF
--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductOptionRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductOptionRepository.java
@@ -1,8 +1,11 @@
 package com.moving.shop.order.domain.repository;
 
 import com.moving.shop.order.domain.entity.OrderProductOption;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface OrderProductOptionRepository extends JpaRepository<OrderProductOption, Long> {
 
+  List<OrderProductOption> findAllByOrderProduct_Id(@RequestParam("order_product_id") Long orderProductId);
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepository.java
@@ -1,8 +1,14 @@
 package com.moving.shop.order.domain.repository;
 
 import com.moving.shop.order.domain.entity.OrderProduct;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface OrderProductRepository extends JpaRepository<OrderProduct, Long> {
 
+  @EntityGraph(attributePaths = {"orderProductOptions"}, type = EntityGraphType.LOAD)
+  Optional<OrderProduct> findWithOrderProductOptionByServiceOrder_Id(@RequestParam("service_order_id") Long serviceOrderId);
 }

--- a/shop/src/test/java/com/moving/shop/order/application/OrderApplicationTest.java
+++ b/shop/src/test/java/com/moving/shop/order/application/OrderApplicationTest.java
@@ -1,0 +1,247 @@
+package com.moving.shop.order.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.moving.shop.common.exception.customexception.CustomerException;
+import com.moving.shop.common.exception.type.CustomerErrorCode;
+import com.moving.shop.common.security.TokenProvider;
+import com.moving.shop.company.application.CompanySignInApplication;
+import com.moving.shop.company.domain.dto.CompanySignInForm;
+import com.moving.shop.company.domain.dto.CompanySignUpForm;
+import com.moving.shop.company.service.CompanySignUpService;
+import com.moving.shop.customer.application.CustomerSignInApplication;
+import com.moving.shop.customer.application.CustomerSignUpApplication;
+import com.moving.shop.customer.domain.dto.ChangeCashForm;
+import com.moving.shop.customer.domain.dto.CustomerRequestForm;
+import com.moving.shop.customer.domain.dto.SignInForm;
+import com.moving.shop.customer.domain.dto.SignUpForm;
+import com.moving.shop.customer.domain.entity.Customer;
+import com.moving.shop.customer.domain.entity.CustomerRequest;
+import com.moving.shop.customer.domain.repository.CustomerRepository;
+import com.moving.shop.customer.domain.repository.CustomerRequestRepository;
+import com.moving.shop.customer.service.CustomerCashService;
+import com.moving.shop.customer.service.CustomerRequestService;
+import com.moving.shop.order.domain.dto.AddOrderProductForm;
+import com.moving.shop.order.domain.dto.AddOrderProductOptionForm;
+import com.moving.shop.order.domain.entity.ServiceOrder;
+import com.moving.shop.product.domain.dto.AddProductOptionForm;
+import com.moving.shop.product.domain.dto.AddServiceProductForm;
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import com.moving.shop.product.service.CompanyProductService;
+import com.moving.shop.product.service.CustomerProductService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+@SpringBootTest
+class OrderApplicationTest {
+
+  @Autowired
+  private OrderApplication orderApplication;
+
+  @Autowired
+  private CustomerCashService customerCashService;
+
+  @Autowired
+  private CustomerRepository customerRepository;
+
+  @Autowired
+  private CustomerRequestRepository customerRequestRepository;
+
+  @Autowired
+  private CustomerProductService customerProductService;
+
+  @Autowired
+  private CompanyProductService companyProductService;
+
+  @Autowired
+  private CompanySignInApplication companySignInApplication;
+
+  @Autowired
+  private CompanySignUpService companySignUpService;
+
+  @Autowired
+  private CustomerSignUpApplication customerSignUpApplication;
+
+  @Autowired
+  private CustomerSignInApplication customerSignInApplication;
+
+  @Autowired
+  private CustomerRequestService customerRequestService;
+
+  @Autowired
+  private TokenProvider tokenProvider;
+
+  @Test
+  void ORDER_PRODUCT_SUCCESS_TEST() {
+
+    //given
+    ServiceProduct firstServiceProduct = addServiceProduct();
+
+    //when
+    String customersJwt = loginCustomer();
+
+    customerCashUpdate(customersJwt);
+
+    AddOrderProductForm orderForm = makeOrderForm(customersJwt);
+
+    ServiceOrder serviceOrder = orderApplication.takeOrder(customersJwt, orderForm);
+
+    //then
+    assertNotNull(serviceOrder);
+    assertEquals(serviceOrder.getCustomerRequest().getId(), orderForm.getCustomerRequestId());
+  }
+
+  private AddOrderProductForm makeOrderForm(String customersJwt) {
+
+    //고객 앞으로 온 서비스 상품 정보를 토대로 주문 form 생성
+    List<ServiceProduct> serviceProductsForRequest = customerProductService.findByCustomerId(customersJwt);
+
+    AddOrderProductOptionForm option = AddOrderProductOptionForm.builder()
+        .productOptionId(serviceProductsForRequest.get(0).getProductOptions().get(0).getId())
+        .optionPrice(serviceProductsForRequest.get(0).getProductOptions().get(0).getOptionPrice())
+        .build();
+
+    AddOrderProductForm orderForm = AddOrderProductForm.builder()
+        .customerRequestId(serviceProductsForRequest.get(0).getCustomerRequest().getId())
+        .serviceProductId(serviceProductsForRequest.get(0).getId())
+        .productPrice(serviceProductsForRequest.get(0).getProductPrice())
+        .addOrderProductOptionForms(Arrays.asList(option))
+        .build();
+    return orderForm;
+  }
+
+  private ServiceProduct addServiceProduct() {
+
+    String companysJwt = makeCompanysJwt();
+    CustomerRequest customerRequest = makeCustomerRequest();
+
+    List<AddProductOptionForm> addProductOptionForms = makeProductOptionForms();
+    AddServiceProductForm addServiceProductForm = AddServiceProductForm.builder()
+        .executeDate(LocalDateTime.now().plusMonths(3))
+        .name("테스트상품")
+        .productOptions(addProductOptionForms)
+        .outlineDescription("테스트용으로 등록하는 상품입니다.")
+        .productPrice(150000)
+        .serviceRequestId(customerRequest.getId())
+        .build();
+    return companyProductService.addServiceProduct(companysJwt, addServiceProductForm);
+  }
+
+
+  private CustomerRequest makeCustomerRequest() {
+
+    //given
+    String customersJwt = makeCustomersJwt();
+
+    CustomerRequestForm form = CustomerRequestForm.builder()
+        .serviceAddress("경기 가평")
+        .desiredDate(LocalDate.now().plusMonths(3))
+        .detailRequest("test 요구사항입니다.")
+        .placeArea(23)
+        .serviceCategory("cleaning")
+        .placeShape("house")
+        .build();
+
+    //when
+    Customer customer = customerRepository.findByEmail(tokenProvider.getUsername(customersJwt))
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_EXIST_MEMBER));
+
+    CustomerRequest customerRequest = CustomerRequest.builder()
+        .customer(customer)
+        .serviceAddress(form.getServiceAddress())
+        .desiredDate(form.getDesiredDate())
+        .detailRequest(form.getDetailRequest())
+        .placeArea(form.getPlaceArea())
+        .serviceCategory(form.getServiceCategoryType())
+        .placeShape(form.getPlaceShapeType())
+        .build();
+    return customerRequestRepository.save(customerRequest);
+  }
+
+  private List<AddProductOptionForm> makeProductOptionForms() {
+
+    List<AddProductOptionForm> addProductOptionForms = new ArrayList<>();
+    AddProductOptionForm addProductOption1 = AddProductOptionForm.builder().name("상품옵션1")
+        .optionPrice(500).build();
+    AddProductOptionForm addProductOption2 = AddProductOptionForm.builder().name("상품옵션1")
+        .optionPrice(500).build();
+    addProductOptionForms.add(addProductOption1);
+    addProductOptionForms.add(addProductOption2);
+    return addProductOptionForms;
+  }
+
+  private String makeCompanysJwt() {
+
+    //given
+    CompanySignUpForm form = CompanySignUpForm.builder()
+        .serviceCategory("cleaning")
+        .email("company@google.com")
+        .password("1111")
+        .address("서울시 영등포구")
+        .addressDetail("가평읍")
+        .zipcode("119662")
+        .tel("01022223333")
+        .introduction("test용 업체 회원가입")
+        .businessNumber("1123345565")
+        .build();
+    companySignUpService.signUp(form);
+
+    CompanySignInForm loginForm = CompanySignInForm.builder()
+        .email("company@google.com")
+        .password("1111")
+        .build();
+    String jwt = companySignInApplication.generateToken(loginForm);
+    return jwt;
+  }
+
+  private String makeCustomersJwt() {
+
+    //given
+    SignUpForm form = SignUpForm.builder()
+        .email("testtest0101@naver.com")
+        .name("testuser")
+        .password("1122")
+        .phone("01012345667").build();
+    customerSignUpApplication.customerSignUp(form);
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest0101@naver.com")
+        .password("1122")
+        .build();
+    String jwt = customerSignInApplication.generateToken(signInForm);
+
+    return jwt;
+  }
+
+  private String loginCustomer() {
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest0101@naver.com")
+        .password("1122")
+        .build();
+    return customerSignInApplication.generateToken(signInForm);
+  }
+
+  private void customerCashUpdate(String customersJwt) {
+
+    //cash update for order product
+    ChangeCashForm changeCashForm = ChangeCashForm.builder()
+        .cash(5000000)
+        .description("CASH UPDATE FOR ORDER-TEST")
+        .fromWhom("TEST-USER")
+        .build();
+    customerCashService.changeCashBalance(customersJwt, changeCashForm);
+  }
+
+}

--- a/shop/src/test/java/com/moving/shop/order/service/CustomerOrderServiceTest.java
+++ b/shop/src/test/java/com/moving/shop/order/service/CustomerOrderServiceTest.java
@@ -1,0 +1,268 @@
+package com.moving.shop.order.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.moving.shop.common.exception.customexception.CustomerException;
+import com.moving.shop.common.exception.customexception.OrderException;
+import com.moving.shop.common.exception.type.CustomerErrorCode;
+import com.moving.shop.common.exception.type.OrderErrorCode;
+import com.moving.shop.common.security.TokenProvider;
+import com.moving.shop.company.application.CompanySignInApplication;
+import com.moving.shop.company.domain.dto.CompanySignInForm;
+import com.moving.shop.company.domain.dto.CompanySignUpForm;
+import com.moving.shop.company.service.CompanySignUpService;
+import com.moving.shop.customer.application.CustomerSignInApplication;
+import com.moving.shop.customer.application.CustomerSignUpApplication;
+import com.moving.shop.customer.domain.dto.ChangeCashForm;
+import com.moving.shop.customer.domain.dto.CustomerRequestForm;
+import com.moving.shop.customer.domain.dto.SignInForm;
+import com.moving.shop.customer.domain.dto.SignUpForm;
+import com.moving.shop.customer.domain.entity.Customer;
+import com.moving.shop.customer.domain.entity.CustomerRequest;
+import com.moving.shop.customer.domain.repository.CustomerRepository;
+import com.moving.shop.customer.domain.repository.CustomerRequestRepository;
+import com.moving.shop.customer.service.CustomerCashService;
+import com.moving.shop.customer.service.CustomerRequestService;
+import com.moving.shop.order.domain.dto.AddOrderProductForm;
+import com.moving.shop.order.domain.dto.AddOrderProductOptionForm;
+import com.moving.shop.order.domain.entity.OrderProduct;
+import com.moving.shop.order.domain.entity.OrderProductOption;
+import com.moving.shop.order.domain.entity.ServiceOrder;
+import com.moving.shop.order.domain.repository.OrderProductOptionRepository;
+import com.moving.shop.order.domain.repository.OrderProductRepository;
+import com.moving.shop.product.domain.dto.AddProductOptionForm;
+import com.moving.shop.product.domain.dto.AddServiceProductForm;
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import com.moving.shop.product.service.CompanyProductService;
+import com.moving.shop.product.service.CustomerProductService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+@SpringBootTest
+class CustomerOrderServiceTest {
+
+  @Autowired
+  private OrderProductOptionRepository orderProductOptionRepository;
+
+  @Autowired
+  private OrderProductRepository orderProductRepository;
+
+  @Autowired
+  private CustomerOrderService customerOrderService;
+
+  @Autowired
+  private CustomerRepository customerRepository;
+
+  @Autowired
+  private CustomerRequestRepository customerRequestRepository;
+
+  @Autowired
+  private CustomerProductService customerProductService;
+
+  @Autowired
+  private CompanyProductService companyProductService;
+
+  @Autowired
+  private CompanySignInApplication companySignInApplication;
+
+  @Autowired
+  private CompanySignUpService companySignUpService;
+
+  @Autowired
+  private CustomerSignUpApplication customerSignUpApplication;
+
+  @Autowired
+  private CustomerSignInApplication customerSignInApplication;
+
+  @Autowired
+  private CustomerRequestService customerRequestService;
+
+  @Autowired
+  private TokenProvider tokenProvider;
+
+  @Test
+  void CREATE_ORDER_DATA_SUCCESS_TEST() {
+
+    //given
+    ServiceProduct serviceProduct = addServiceProduct();
+
+    //when
+    String customersJwt = loginCustomer();
+
+    AddOrderProductForm orderProductForm = makeOrderFormWithAllOptions(customersJwt);
+
+    //new 주문서비스 return
+    ServiceOrder serviceOrder = customerOrderService.createOrder(orderProductForm);
+
+    //주문서비스상품(주문서비스옵션과 함께) data select (key: 고객의 주문서비스 id)
+    OrderProduct orderProduct = orderProductRepository.findWithOrderProductOptionByServiceOrder_Id(serviceOrder.getId())
+        .orElseThrow(() -> new OrderException(OrderErrorCode.NOT_VALID_PRODUCT_INFO));
+
+    //주문서비스상품옵션 목록만 select (key: 주문서비스상품 id)
+    List<OrderProductOption> orderProductOptions = orderProductOptionRepository.findAllByOrderProduct_Id(orderProduct.getId());
+
+    //then
+    assertNotNull(serviceOrder);
+    assertNotNull(orderProduct);
+    assertNotNull(orderProduct.getOrderProductOptions());
+
+    assertEquals(orderProduct.getOrderProductOptions().size(), orderProductForm.getAddOrderProductOptionForms().size());
+    assertEquals(orderProduct.getOrderProductOptions().get(0).getOptionPrice(), 500);
+    assertEquals(orderProduct.getOrderProductOptions().get(0).getOptionPrice(), orderProductForm.getAddOrderProductOptionForms().get(0).getOptionPrice());
+    assertEquals(orderProduct.getOrderProductOptions().get(1).getOptionPrice(), 1000);
+    assertEquals(orderProduct.getOrderProductOptions().get(1).getOptionPrice(), orderProductForm.getAddOrderProductOptionForms().get(1).getOptionPrice());
+
+    assertEquals(orderProductOptions.size(), 2);
+    assertEquals(orderProductOptions.get(0).getOptionPrice(), 500);
+    assertEquals(orderProductOptions.get(1).getOptionPrice(), 1000);
+  }
+
+  private AddOrderProductForm makeOrderFormWithAllOptions(String customersJwt) {
+
+    //고객 앞으로 온 서비스 상품 정보를 토대로 주문 form 생성
+    List<ServiceProduct> serviceProductsForRequest = customerProductService.findByCustomerId(customersJwt);
+    //서비스 상품 정보 내의 모든 옵션 포함하여 주문 form 생성
+    List<AddOrderProductOptionForm> options = new ArrayList<>();
+    for (int i=0; i<serviceProductsForRequest.get(0).getProductOptions().size(); i++) {
+
+      AddOrderProductOptionForm optionForm = AddOrderProductOptionForm.builder()
+          .productOptionId(serviceProductsForRequest.get(0).getProductOptions().get(i).getId())
+          .optionPrice(serviceProductsForRequest.get(0).getProductOptions().get(i).getOptionPrice())
+          .build();
+      options.add(optionForm);
+    }
+
+    AddOrderProductForm orderForm = AddOrderProductForm.builder()
+        .customerRequestId(serviceProductsForRequest.get(0).getCustomerRequest().getId())
+        .serviceProductId(serviceProductsForRequest.get(0).getId())
+        .productPrice(serviceProductsForRequest.get(0).getProductPrice())
+        .addOrderProductOptionForms(options)
+        .build();
+    return orderForm;
+  }
+
+  private ServiceProduct addServiceProduct() {
+
+    String companysJwt = makeCompanysJwt();
+    CustomerRequest customerRequest = makeCustomerRequest();
+
+    List<AddProductOptionForm> addProductOptionForms = makeProductOptionForms();
+    AddServiceProductForm addServiceProductForm = AddServiceProductForm.builder()
+        .executeDate(LocalDateTime.now().plusMonths(3))
+        .name("테스트상품")
+        .productOptions(addProductOptionForms)
+        .outlineDescription("테스트용으로 등록하는 상품입니다.")
+        .productPrice(150000)
+        .serviceRequestId(customerRequest.getId())
+        .build();
+    return companyProductService.addServiceProduct(companysJwt, addServiceProductForm);
+  }
+
+
+  private CustomerRequest makeCustomerRequest() {
+
+    //given
+    String customersJwt = makeCustomersJwt();
+
+    CustomerRequestForm form = CustomerRequestForm.builder()
+        .serviceAddress("경기 가평")
+        .desiredDate(LocalDate.now().plusMonths(3))
+        .detailRequest("test 요구사항입니다.")
+        .placeArea(23)
+        .serviceCategory("cleaning")
+        .placeShape("house")
+        .build();
+
+    //when
+    Customer customer = customerRepository.findByEmail(tokenProvider.getUsername(customersJwt))
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_EXIST_MEMBER));
+
+    CustomerRequest customerRequest = CustomerRequest.builder()
+        .customer(customer)
+        .serviceAddress(form.getServiceAddress())
+        .desiredDate(form.getDesiredDate())
+        .detailRequest(form.getDetailRequest())
+        .placeArea(form.getPlaceArea())
+        .serviceCategory(form.getServiceCategoryType())
+        .placeShape(form.getPlaceShapeType())
+        .build();
+    return customerRequestRepository.save(customerRequest);
+  }
+
+  private List<AddProductOptionForm> makeProductOptionForms() {
+
+    List<AddProductOptionForm> addProductOptionForms = new ArrayList<>();
+    AddProductOptionForm addProductOption1 = AddProductOptionForm.builder().name("상품옵션1")
+        .optionPrice(500).build();
+    AddProductOptionForm addProductOption2 = AddProductOptionForm.builder().name("상품옵션2")
+        .optionPrice(1000).build();
+    addProductOptionForms.add(addProductOption1);
+    addProductOptionForms.add(addProductOption2);
+    return addProductOptionForms;
+  }
+
+  private String makeCompanysJwt() {
+
+    //given
+    CompanySignUpForm form = CompanySignUpForm.builder()
+        .serviceCategory("cleaning")
+        .email("company@google.com")
+        .password("1111")
+        .address("서울시 영등포구")
+        .addressDetail("가평읍")
+        .zipcode("119662")
+        .tel("01022223333")
+        .introduction("test용 업체 회원가입")
+        .businessNumber("1123345565")
+        .build();
+    companySignUpService.signUp(form);
+
+    CompanySignInForm loginForm = CompanySignInForm.builder()
+        .email("company@google.com")
+        .password("1111")
+        .build();
+    String jwt = companySignInApplication.generateToken(loginForm);
+    return jwt;
+  }
+
+  private String makeCustomersJwt() {
+
+    //given
+    SignUpForm form = SignUpForm.builder()
+        .email("testtest0101@naver.com")
+        .name("testuser")
+        .password("1122")
+        .phone("01012345667").build();
+    customerSignUpApplication.customerSignUp(form);
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest0101@naver.com")
+        .password("1122")
+        .build();
+    String jwt = customerSignInApplication.generateToken(signInForm);
+
+    return jwt;
+  }
+
+  private String loginCustomer() {
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest0101@naver.com")
+        .password("1122")
+        .build();
+    return customerSignInApplication.generateToken(signInForm);
+  }
+
+
+}


### PR DESCRIPTION
:white_check_mark: Changes

- 주문 기능 test code 작성을 바탕으로, 주문 시 필요한 조회 값을 가져오는 데 필요한 JPA 라인을 추가하였습니다.

<br>

:heavy_plus_sign: Related Details

- 주문 기능을 처리하는 order application layer의 test code를 작성하였습니다. 
(1)고객의 잔금을 확인합니다

- 주문 기능을 처리하는 application에서 호출하는 주문 관련 table data 생성 service layer의 test code를 작성하였습니다. 
 (1)올바른 주문상품키를 들고서 주문상품옵션 data가 생성되었는지 확인합니다. 
(2)주문 키를 가지고 주문상품-주문상품옵션을 모두 가져올 수 있는지 확인합니다.

- 주문 data 생성 관련 test code를 작성하며  주문상품 조회 시, 주문상품 옵션도 같이 select해오도록 추가적으로 필요한 JPA 라인을 더했습니다.

<br>

:pray: Reference
- `@EntityGraph`를 통해서 상품을 가져올 때 상품옵션을 같이 select하도록 할 때 참고한 블로그 포스팅입니다.
 https://kok202.tistory.com/177
