### PR TITLE
feat: [CUSTOMER-VIEW] 고객의 상품 조회, 상품리스트 조회 기능 추가

### DIFF
--- a/shop/build.gradle
+++ b/shop/build.gradle
@@ -52,9 +52,9 @@ dependencies {
 	implementation ('it.ozimov:embedded-redis:0.7.1') {
 		exclude group: 'org.slf4j', module: 'slf4j-simple'
 	}
-	testImplementation ('it.ozimov.embedded-redis:0.7.1') {
-		exclude group: "org.slf4j", module: "slf4j-simple"
-	}
+//	testImplementation ('it.ozimov.embedded-redis:0.7.1') {
+//		exclude group: "org.slf4j", module: "slf4j-simple"
+//	}
 
 	//webSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/shop/src/main/java/com/moving/shop/company/controller/CompanyController.java
+++ b/shop/src/main/java/com/moving/shop/company/controller/CompanyController.java
@@ -5,6 +5,7 @@ import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_PREF
 
 import com.moving.shop.company.domain.dto.CompanyInfo;
 import com.moving.shop.company.service.CompanyService;
+import com.moving.shop.customer.service.CustomerRequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,12 +20,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class CompanyController {
 
   private final CompanyService companyService;
+  private final CustomerRequestService customerRequestService;
 
   @GetMapping
   @PreAuthorize("hasAuthority('COMPANY')")
-  public ResponseEntity<CompanyInfo> getCustomerInfo(@RequestHeader(value = TOKEN_HEADER) String token) {
+  public ResponseEntity<CompanyInfo> getCompanyInfo(@RequestHeader(value = TOKEN_HEADER) String token) {
 
     String refinedToken = token.substring(TOKEN_PREFIX.length());
     return ResponseEntity.ok(companyService.getCompanyInfo(refinedToken));
   }
+
+  @GetMapping("/customer-requests")
+  @PreAuthorize("hasAuthority('COMPANY')")
+  public ResponseEntity<?> getCustomerRequests(@RequestHeader(value = TOKEN_HEADER) String token) {
+    return ResponseEntity.ok(customerRequestService.getCustomerRequests());
+  }
+
 }

--- a/shop/src/main/java/com/moving/shop/company/domain/dto/CompanyInformationForm.java
+++ b/shop/src/main/java/com/moving/shop/company/domain/dto/CompanyInformationForm.java
@@ -16,6 +16,9 @@ public class CompanyInformationForm {
   /* 가입 이메일 */
   private String email;
 
+  /* 업체명 */
+  private String name;
+  
   /* 서비스카테고리 */
   private ServiceCategory serviceCategory;
 
@@ -32,6 +35,7 @@ public class CompanyInformationForm {
     return CompanyInformationForm.builder()
         .serviceCategory(company.getServiceCategory())
         .email(company.getEmail())
+        .name(company.getName())
         .address(company.getAddress())
         .tel(company.getTel())
         .introduction(company.getIntroduction())

--- a/shop/src/main/java/com/moving/shop/company/domain/entity/Company.java
+++ b/shop/src/main/java/com/moving/shop/company/domain/entity/Company.java
@@ -1,5 +1,6 @@
 package com.moving.shop.company.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.company.domain.dto.CompanySignUpForm;
 import com.moving.shop.customer.domain.type.MemberType;
@@ -40,6 +41,7 @@ public class Company extends BaseEntity {
   private String email;
 
   /* 비밀번호 */
+  @JsonIgnore
   private String password;
   
   /* 업체명 */
@@ -61,6 +63,7 @@ public class Company extends BaseEntity {
   private String introduction;
 
   /* 업체 승인여부 */
+  @JsonIgnore
   private boolean approvalYn;
 
   /* 사업자번호 */

--- a/shop/src/main/java/com/moving/shop/customer/domain/dto/CustomerRequestResponse.java
+++ b/shop/src/main/java/com/moving/shop/customer/domain/dto/CustomerRequestResponse.java
@@ -1,0 +1,51 @@
+package com.moving.shop.customer.domain.dto;
+
+import com.moving.shop.customer.domain.entity.CustomerRequest;
+import com.moving.shop.customer.domain.type.PlaceShape;
+import com.moving.shop.customer.domain.type.ServiceCategory;
+import java.time.LocalDate;
+import java.util.Locale;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerRequestResponse {
+
+  private Long id;
+
+  /* 서비스 주소지 */
+  private String serviceAddress;
+
+  /* 서비스 시행 요청일 */
+  private LocalDate desiredDate;
+
+  /* 상세요청사항 */
+  private String detailRequest;
+
+  /* 장소면적 (평) */
+  private Integer placeArea;
+
+  /* 서비스 카테고리 */
+  private String serviceCategory;
+
+  /* 서비스 장소 구조 */
+  private String placeShape;
+
+  public static CustomerRequestResponse from(CustomerRequest customerRequest) {
+    return CustomerRequestResponse.builder()
+        .id(customerRequest.getId())
+        .serviceAddress(customerRequest.getServiceAddress())
+        .desiredDate(customerRequest.getDesiredDate())
+        .detailRequest(customerRequest.getDetailRequest())
+        .placeArea(customerRequest.getPlaceArea())
+        .serviceCategory(String.valueOf(customerRequest.getServiceCategory()))
+        .placeShape(String.valueOf(customerRequest.getPlaceShape()))
+        .build();
+  }
+
+}

--- a/shop/src/main/java/com/moving/shop/customer/domain/dto/CustomerRequestResponse.java
+++ b/shop/src/main/java/com/moving/shop/customer/domain/dto/CustomerRequestResponse.java
@@ -1,5 +1,7 @@
 package com.moving.shop.customer.domain.dto;
 
+import static com.moving.shop.customer.domain.type.ServiceCategory.CLEANING;
+
 import com.moving.shop.customer.domain.entity.CustomerRequest;
 import com.moving.shop.customer.domain.type.PlaceShape;
 import com.moving.shop.customer.domain.type.ServiceCategory;
@@ -36,6 +38,27 @@ public class CustomerRequestResponse {
   /* 서비스 장소 구조 */
   private String placeShape;
 
+  private static String readServiceCategory(ServiceCategory serviceCategory) {
+    return CLEANING.equals(serviceCategory) ? "청소" : "인테리어시공";
+  }
+
+  private static String readPlaceShape(PlaceShape placeShape) {
+
+    if (PlaceShape.APARTMENT.equals(placeShape)) {
+      return "아파트";
+    }
+
+    if (PlaceShape.HOUSE.equals(placeShape)) {
+      return "빌라";
+    }
+
+    if (PlaceShape.SINGLE_HOUSE.equals(placeShape)) {
+      return "단독주택";
+    }
+
+    return "기타";
+  }
+
   public static CustomerRequestResponse from(CustomerRequest customerRequest) {
     return CustomerRequestResponse.builder()
         .id(customerRequest.getId())
@@ -43,8 +66,8 @@ public class CustomerRequestResponse {
         .desiredDate(customerRequest.getDesiredDate())
         .detailRequest(customerRequest.getDetailRequest())
         .placeArea(customerRequest.getPlaceArea())
-        .serviceCategory(String.valueOf(customerRequest.getServiceCategory()))
-        .placeShape(String.valueOf(customerRequest.getPlaceShape()))
+        .serviceCategory(readServiceCategory(customerRequest.getServiceCategory()))
+        .placeShape(readPlaceShape(customerRequest.getPlaceShape()))
         .build();
   }
 

--- a/shop/src/main/java/com/moving/shop/customer/domain/entity/CustomerRequest.java
+++ b/shop/src/main/java/com/moving/shop/customer/domain/entity/CustomerRequest.java
@@ -1,5 +1,6 @@
 package com.moving.shop.customer.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.customer.domain.type.PlaceShape;
 import com.moving.shop.customer.domain.type.ServiceCategory;
@@ -34,6 +35,7 @@ public class CustomerRequest extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @JsonIgnore
   @ManyToOne(targetEntity = Customer.class, fetch = FetchType.LAZY)
   private Customer customer;
 

--- a/shop/src/main/java/com/moving/shop/customer/service/CustomerRequestService.java
+++ b/shop/src/main/java/com/moving/shop/customer/service/CustomerRequestService.java
@@ -2,11 +2,15 @@ package com.moving.shop.customer.service;
 
 import com.moving.shop.customer.domain.dto.CustomerInfo;
 import com.moving.shop.customer.domain.dto.CustomerRequestForm;
+import com.moving.shop.customer.domain.dto.CustomerRequestResponse;
 import com.moving.shop.customer.domain.entity.CustomerRequest;
+import java.util.List;
 
 public interface CustomerRequestService {
 
   CustomerRequestForm addCustomerRequest(String refinedToken, CustomerRequestForm form);
 
   CustomerInfo getCustomerInfo(String refinedToken);
+
+  List<CustomerRequestResponse> getCustomerRequests();
 }

--- a/shop/src/main/java/com/moving/shop/customer/service/impl/CustomerRequestServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/customer/service/impl/CustomerRequestServiceImpl.java
@@ -5,12 +5,16 @@ import com.moving.shop.common.exception.type.CustomerErrorCode;
 import com.moving.shop.common.security.TokenProvider;
 import com.moving.shop.customer.domain.dto.CustomerInfo;
 import com.moving.shop.customer.domain.dto.CustomerRequestForm;
+import com.moving.shop.customer.domain.dto.CustomerRequestResponse;
 import com.moving.shop.customer.domain.entity.Customer;
 import com.moving.shop.customer.domain.entity.CustomerRequest;
 import com.moving.shop.customer.domain.repository.CustomerRepository;
 import com.moving.shop.customer.domain.repository.CustomerRequestRepository;
 import com.moving.shop.customer.service.CustomerRequestService;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,5 +57,18 @@ public class CustomerRequestServiceImpl implements CustomerRequestService {
         .name(customer.getName())
         .phone(customer.getPhone())
         .build();
+  }
+
+  @Override
+  public List<CustomerRequestResponse> getCustomerRequests() {
+
+    List<CustomerRequest> customerRequests = customerRequestRepository.findAll(Sort.by(
+        Sort.Direction.DESC, "id"));
+    if (customerRequests.isEmpty()) {
+      return null;
+    }
+
+    return customerRequests.stream()
+        .map(customerRequest -> CustomerRequestResponse.from(customerRequest)).collect(Collectors.toList());
   }
 }

--- a/shop/src/main/java/com/moving/shop/product/controller/CustomerProductController.java
+++ b/shop/src/main/java/com/moving/shop/product/controller/CustomerProductController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +27,12 @@ public class CustomerProductController {
 
     String refinedToken = token.substring(TOKEN_PREFIX.length());
     return ResponseEntity.ok(ProposedProductResponse.from(customerProductService.findByCustomerId(refinedToken)));
+  }
+
+  @GetMapping("/{id}")
+  @PreAuthorize("hasAuthority('CUSTOMER')")
+  public ResponseEntity<?> getCustomersReceivedProduct(@PathVariable("id")Long serviceProductId) {
+    return ResponseEntity.ok(customerProductService.findWithProductOptionsById(serviceProductId));
   }
 
 }

--- a/shop/src/main/java/com/moving/shop/product/domain/entity/ProductOption.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/entity/ProductOption.java
@@ -1,5 +1,6 @@
 package com.moving.shop.product.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.product.domain.dto.AddProductOptionForm;
 import javax.persistence.Entity;
@@ -29,6 +30,7 @@ public class ProductOption extends BaseEntity {
   private Long id;
 
   /* 서비스상품 ID */
+  @JsonBackReference //양방향 매핑 시 순환참조 방지
   @ManyToOne
   @JoinColumn(name = "service_product_id")
   private ServiceProduct serviceProduct;

--- a/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
@@ -1,6 +1,7 @@
 package com.moving.shop.product.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.company.domain.entity.Company;
 import com.moving.shop.customer.domain.entity.CustomerRequest;
@@ -43,7 +44,8 @@ public class ServiceProduct extends BaseEntity {
   private Company company;
 
   /* 서비스상품_옵션 */
-  @JsonIgnore
+//  @JsonIgnore
+  @JsonManagedReference //양방향 매핑 시 순환참조 방지
   @OneToMany(cascade = CascadeType.ALL)
   @JoinColumn(name = "service_product_id")
   private List<ProductOption> productOptions = new ArrayList<>();

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepository.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepository.java
@@ -1,8 +1,13 @@
 package com.moving.shop.product.domain.repository;
 
 import com.moving.shop.product.domain.entity.ServiceProduct;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ServiceProductRepository extends JpaRepository<ServiceProduct, Long>, ServiceProductRepositoryCustom {
 
+  @EntityGraph(attributePaths = {"productOptions"}, type = EntityGraphType.LOAD)
+  Optional<ServiceProduct> findWithProductOptionsById(Long id);
 }

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustom.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustom.java
@@ -7,4 +7,7 @@ public interface ServiceProductRepositoryCustom {
 
   List<ServiceProduct> findByCustomerId(Long customerId);
 
+  // n + 1 쿼리 나가는 문제 발생
+  //List<ServiceProduct> findWithProductOptionsById(Long serviceProductId);
+
 }

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepositoryCustomImpl.java
@@ -1,6 +1,8 @@
 package com.moving.shop.product.domain.repository;
 
+import com.moving.shop.company.domain.entity.QCompany;
 import com.moving.shop.customer.domain.entity.QCustomerRequest;
+import com.moving.shop.product.domain.entity.QProductOption;
 import com.moving.shop.product.domain.entity.QServiceProduct;
 import com.moving.shop.product.domain.entity.ServiceProduct;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,4 +27,21 @@ public class ServiceProductRepositoryCustomImpl implements ServiceProductReposit
         .where(customerRequest.customer.id.eq(customerId))
         .fetch();
   }
+
+  //fetch join으로 해결할 것이 아니라 return 용 dto를 만들어서 하는 법으로 수정 필요.
+//  @Override
+//  public List<ServiceProduct> findWithProductOptionsById(Long serviceProductId) {
+//
+//    QServiceProduct serviceProduct = QServiceProduct.serviceProduct;
+//    QProductOption productOption = QProductOption.productOption;
+//    QCompany company = QCompany.company;
+//    QCustomerRequest customerRequest = QCustomerRequest.customerRequest;
+//
+//    return jpaQueryFactory.selectFrom(serviceProduct)
+//        .join(serviceProduct.productOptions, productOption).fetchJoin()
+//        .join(serviceProduct.company, company).fetchJoin()
+//        .join(serviceProduct.customerRequest, customerRequest).fetchJoin()
+//        .where(serviceProduct.id.eq(serviceProductId))
+//        .fetch();
+//  }
 }

--- a/shop/src/main/java/com/moving/shop/product/service/CustomerProductService.java
+++ b/shop/src/main/java/com/moving/shop/product/service/CustomerProductService.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface CustomerProductService {
 
   List<ServiceProduct> findByCustomerId(String refinedToken);
+
+  ServiceProduct findWithProductOptionsById(Long serviceProductId);
 }

--- a/shop/src/main/java/com/moving/shop/product/service/impl/CustomerProductServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/service/impl/CustomerProductServiceImpl.java
@@ -1,6 +1,7 @@
 package com.moving.shop.product.service.impl;
 
 import com.moving.shop.common.exception.customexception.CustomerException;
+import com.moving.shop.common.exception.customexception.OrderException;
 import com.moving.shop.common.exception.type.CustomerErrorCode;
 import com.moving.shop.common.security.TokenProvider;
 import com.moving.shop.customer.domain.entity.Customer;
@@ -28,5 +29,14 @@ public class CustomerProductServiceImpl implements CustomerProductService {
         .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_EXIST_MEMBER));
 
     return serviceProductRepository.findByCustomerId(customer.getId());
+  }
+
+  @Override
+  public ServiceProduct findWithProductOptionsById(Long serviceProductId) {
+
+    ServiceProduct serviceProductWithOptions = serviceProductRepository.findWithProductOptionsById(serviceProductId)
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_CORRECT_INPUT));
+
+    return serviceProductWithOptions;
   }
 }

--- a/shop/src/test/java/com/moving/shop/customer/service/CustomerRequestServiceTest.java
+++ b/shop/src/test/java/com/moving/shop/customer/service/CustomerRequestServiceTest.java
@@ -1,0 +1,117 @@
+package com.moving.shop.customer.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.moving.shop.common.exception.customexception.CustomerException;
+import com.moving.shop.common.exception.type.CustomerErrorCode;
+import com.moving.shop.common.security.TokenProvider;
+import com.moving.shop.customer.application.CustomerSignInApplication;
+import com.moving.shop.customer.application.CustomerSignUpApplication;
+import com.moving.shop.customer.domain.dto.CustomerRequestForm;
+import com.moving.shop.customer.domain.dto.CustomerRequestResponse;
+import com.moving.shop.customer.domain.dto.SignInForm;
+import com.moving.shop.customer.domain.dto.SignUpForm;
+import com.moving.shop.customer.domain.entity.Customer;
+import com.moving.shop.customer.domain.entity.CustomerRequest;
+import com.moving.shop.customer.domain.repository.CustomerRepository;
+import com.moving.shop.customer.domain.repository.CustomerRequestRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+@SpringBootTest
+class CustomerRequestServiceTest {
+
+  @Autowired
+  private CustomerSignUpApplication customerSignUpApplication;
+
+  @Autowired
+  private CustomerSignInApplication customerSignInApplication;
+
+  @Autowired
+  private CustomerRequestService customerRequestService;
+
+  @Autowired
+  private CustomerRequestRepository customerRequestRepository;
+
+  @Autowired
+  private CustomerRepository customerRepository;
+
+  @Autowired
+  private TokenProvider tokenProvider;
+
+  @Test
+  void GET_CUSTOMER_REQUESTS_SUCCESS_TEST() {
+
+    //given
+    signUpCustomer();
+
+    //when
+    makeCustomerRequest();
+
+    //then
+    List<CustomerRequestResponse> customerRequestResponse = customerRequestService.getCustomerRequests();
+    assertEquals(23, customerRequestResponse.get(0).getPlaceArea());
+    assertEquals("경기 가평", customerRequestResponse.get(0).getServiceAddress());
+    assertEquals("CLEANING", customerRequestResponse.get(0).getServiceCategory());
+    assertEquals("HOUSE", customerRequestResponse.get(0).getPlaceShape());
+  }
+
+  private CustomerRequest makeCustomerRequest() {
+
+    //given
+    String customersJwt = loginCustomer();
+
+    CustomerRequestForm form = CustomerRequestForm.builder()
+        .serviceAddress("경기 가평")
+        .desiredDate(LocalDate.now().plusMonths(3))
+        .detailRequest("test 요구사항입니다.")
+        .placeArea(23)
+        .serviceCategory("cleaning")
+        .placeShape("house")
+        .build();
+
+    //when
+    Customer customer = customerRepository.findByEmail(tokenProvider.getUsername(customersJwt))
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_EXIST_MEMBER));
+
+    CustomerRequest customerRequest = CustomerRequest.builder()
+        .customer(customer)
+        .serviceAddress(form.getServiceAddress())
+        .desiredDate(form.getDesiredDate())
+        .detailRequest(form.getDetailRequest())
+        .placeArea(form.getPlaceArea())
+        .serviceCategory(form.getServiceCategoryType())
+        .placeShape(form.getPlaceShapeType())
+        .build();
+    return customerRequestRepository.save(customerRequest);
+  }
+
+  private void signUpCustomer() {
+
+    //given
+    SignUpForm form = SignUpForm.builder()
+        .email("testtest010101@naver.com")
+        .name("testuser")
+        .password("1122")
+        .phone("01012345667").build();
+    customerSignUpApplication.customerSignUp(form);
+  }
+
+  private String loginCustomer() {
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest010101@naver.com")
+        .password("1122")
+        .build();
+    return customerSignInApplication.generateToken(signInForm);
+  }
+
+}

--- a/shop/src/test/java/com/moving/shop/customer/service/CustomerRequestServiceTest.java
+++ b/shop/src/test/java/com/moving/shop/customer/service/CustomerRequestServiceTest.java
@@ -60,8 +60,8 @@ class CustomerRequestServiceTest {
     List<CustomerRequestResponse> customerRequestResponse = customerRequestService.getCustomerRequests();
     assertEquals(23, customerRequestResponse.get(0).getPlaceArea());
     assertEquals("경기 가평", customerRequestResponse.get(0).getServiceAddress());
-    assertEquals("CLEANING", customerRequestResponse.get(0).getServiceCategory());
-    assertEquals("HOUSE", customerRequestResponse.get(0).getPlaceShape());
+    assertEquals("청소", customerRequestResponse.get(0).getServiceCategory());
+    assertEquals("빌라", customerRequestResponse.get(0).getPlaceShape());
   }
 
   private CustomerRequest makeCustomerRequest() {

--- a/shop/vue-frontend/src/components/common/HeaderVue.vue
+++ b/shop/vue-frontend/src/components/common/HeaderVue.vue
@@ -19,6 +19,12 @@
       </b-navbar-nav>
 
       <b-navbar-nav v-if="this.$store.state.userStore.userType == 'CUSTOMER'">
+        <router-link to="/customer/receivedProducts">
+        <b-nav-item href="/customer/receivedProducts">제안 상품목록</b-nav-item>
+        </router-link>
+      </b-navbar-nav>
+
+      <b-navbar-nav v-if="this.$store.state.userStore.userType == 'CUSTOMER'">
         <router-link to="/chat/list">
         <b-nav-item href="/chat/list">상품 1:1 문의</b-nav-item>
         </router-link>

--- a/shop/vue-frontend/src/components/common/HeaderVue.vue
+++ b/shop/vue-frontend/src/components/common/HeaderVue.vue
@@ -1,14 +1,32 @@
 <template>
 <div>
   <b-navbar toggleable="lg" type="dark" variant="info">
-    <b-navbar-brand href="#">NavBar</b-navbar-brand>
+    <b-navbar-brand href="/#/">Home</b-navbar-brand>
 
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
 
     <b-collapse id="nav-collapse" is-nav>
-      <b-navbar-nav>
+      <b-navbar-nav v-if="!this.$store.state.userStore.isLogin">
         <router-link to="/login">
-        <b-nav-item href="/login">로그인하기</b-nav-item>
+        <b-nav-item href="/login">로그인</b-nav-item>
+        </router-link>
+      </b-navbar-nav>
+
+      <b-navbar-nav v-if="!this.$store.state.userStore.isLogin">
+        <router-link to="/sign-up/company">
+        <b-nav-item href="/sign-up/company">회원가입</b-nav-item>
+        </router-link>
+      </b-navbar-nav>
+
+      <b-navbar-nav v-if="this.$store.state.userStore.userType == 'CUSTOMER'">
+        <router-link to="/chat/list">
+        <b-nav-item href="/chat/list">상품 1:1 문의</b-nav-item>
+        </router-link>
+      </b-navbar-nav>
+
+      <b-navbar-nav v-if="this.$store.state.userStore.userType == 'COMPANY'">
+        <router-link to="/company/chat/list">
+        <b-nav-item href="/company/chat/list">고객 상품 1:1 문의</b-nav-item>
         </router-link>
       </b-navbar-nav>
 
@@ -19,7 +37,7 @@
           <b-button size="sm" class="my-2 my-sm-0" type="submit">Search</b-button>
         </b-nav-form>
 
-        <b-nav-item-dropdown right>
+        <b-nav-item-dropdown v-if="this.$store.state.userStore.isLogin" right>
           <!-- Using 'button-content' slot -->
           <template #button-content>
             <em>User</em>

--- a/shop/vue-frontend/src/components/common/HeaderVue.vue
+++ b/shop/vue-frontend/src/components/common/HeaderVue.vue
@@ -30,6 +30,12 @@
         </router-link>
       </b-navbar-nav>
 
+      <b-navbar-nav v-if="this.$store.state.userStore.userType == 'COMPANY'">
+        <router-link to="/company/requests">
+        <b-nav-item href="/company/requests">고객 견적문의서</b-nav-item>
+        </router-link>
+      </b-navbar-nav>
+
       <!-- Right aligned nav items -->
       <b-navbar-nav class="ml-auto">
         <b-nav-form>

--- a/shop/vue-frontend/src/router/index.js
+++ b/shop/vue-frontend/src/router/index.js
@@ -11,6 +11,8 @@ import ChatRoomView from "../views/chat/ChatDetailView.vue"
 import CompanyChatListView from "../views/chat/CompanyChatListView.vue"
 import CompanyChatRoomView from "../views/chat/CompanyChatDetailView.vue"
 import CustomerRequestListView from "../views/company/CustomerRequestListView.vue"
+import CustomersProductsListView from "../views/customer/ReceivedProductListView.vue"
+import CustomersProductsDetailView from "../views/customer/ReceivedProductDetailView.vue"
 
 import { createRouter, createWebHistory } from 'vue-router'
 
@@ -74,6 +76,16 @@ const routes = [
     path: '/company/requests',
     name: 'requestList',
     component: CustomerRequestListView
+  },
+  {
+    path: '/customer/receivedProducts',
+    name: 'receivedProducts',
+    component: CustomersProductsListView
+  },
+  {
+    path: '/customer/receivedProductDetail',
+    name: 'receivedProductDetail',
+    component: CustomersProductsDetailView
   }
 ]
 

--- a/shop/vue-frontend/src/router/index.js
+++ b/shop/vue-frontend/src/router/index.js
@@ -10,6 +10,7 @@ import ChatListView from "../views/chat/ChatListView.vue"
 import ChatRoomView from "../views/chat/ChatDetailView.vue"
 import CompanyChatListView from "../views/chat/CompanyChatListView.vue"
 import CompanyChatRoomView from "../views/chat/CompanyChatDetailView.vue"
+import CustomerRequestListView from "../views/company/CustomerRequestListView.vue"
 
 import { createRouter, createWebHistory } from 'vue-router'
 
@@ -68,6 +69,11 @@ const routes = [
     path: '/company/chat/room',
     name: 'companyChatroom',
     component: CompanyChatRoomView
+  },
+  {
+    path: '/company/requests',
+    name: 'requestList',
+    component: CustomerRequestListView
   }
 ]
 

--- a/shop/vue-frontend/src/store/modules/userStore.js
+++ b/shop/vue-frontend/src/store/modules/userStore.js
@@ -4,16 +4,28 @@ const userStore = {
     
     state: {
 
-        token: ''
+        token: '',
+        isLogin: false,
+        userType: ''
     },
     mutations: {
     
         setToken: function(state, payload) {
             state.token = payload;
+            state.isLogin = true;
+            state.userType = 'CUSTOMER';
+        },
+
+        setCompanyToken: function(state, payload) {
+            state.token = payload;
+            state.isLogin = true;
+            state.userType = 'COMPANY';
         },
 
         clearToken: function(state) {
             state.token = '';
+            state.isLogin = false;
+            state.userType = '';
         }
     },
     actions: {

--- a/shop/vue-frontend/src/views/common/CompanyLoginView.vue
+++ b/shop/vue-frontend/src/views/common/CompanyLoginView.vue
@@ -59,7 +59,7 @@ export default {
 
           if(response.status === 200) {
             console.log(JSON.stringify(response.data));
-            this.$store.commit('setToken', response.data);
+            this.$store.commit('setCompanyToken', response.data);
             this.$router.push("/"); //로그인 성공하면 main page 이동
           }
         })

--- a/shop/vue-frontend/src/views/common/LoginView.vue
+++ b/shop/vue-frontend/src/views/common/LoginView.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div id="login-page">
-      <h2>Log In</h2>
+      <h2>Log In (Customer) </h2>
       <div id="loginForm">
         <form @submit.prevent="fnLogin">
 
@@ -18,6 +18,10 @@
           <div>
             <b-button block variant="success" @click="login()">Login</b-button>
           </div>
+
+          <router-link to="/login/company">
+          <b-button variant="info" id="company-link-btn">업체회원이신가요? 업체회원으로 로그인하기</b-button>
+          </router-link>
 
         </form>
       </div>
@@ -88,5 +92,9 @@ export default {
 
 #login-page {
   padding-top: 70px;
+}
+
+#company-link-btn {
+  margin-top: 30px;
 }
 </style>

--- a/shop/vue-frontend/src/views/company/CustomerRequestListView.vue
+++ b/shop/vue-frontend/src/views/company/CustomerRequestListView.vue
@@ -1,0 +1,79 @@
+<template>
+
+    <div id="request-info-list">
+
+        <b-alert show>고객 견적문의 목록</b-alert>
+        <b-card v-for="(item, id) in items" :key="id" bg-variant="white" text-variant="dark">
+        <b-card-text class="mr-auto" >
+        <b-icon icon="check-square" scale="2" variant="success"></b-icon>
+        <span class="info">카테고리: {{ item.serviceCategory }}</span>, 
+        
+        <b-icon icon="person-bounding-box" scale="2" variant="warning"></b-icon>
+        <span class="info">{{ item.serviceAddress }},</span>
+        
+        <b-icon icon="building" scale="2" variant="info"></b-icon>
+        <span class="info">{{ item.placeShape }}</span>
+
+        <b-icon icon="alarm" scale="2" variant="warning"></b-icon>
+        <span class="info">희망일: {{ item.desiredDate }}</span>
+        
+        <a v-on:click="onRowSelected(`${item.id}`)">
+        <b-button variant="light">상품 제안하기</b-button>
+        </a>
+        </b-card-text>
+        </b-card>
+    </div>
+
+</template>
+
+<script>
+
+export default {
+
+    data() {
+      return {
+
+        items: [],
+        requestBody: {}
+      }
+    },
+
+    mounted() {
+      this.getRequestList();
+    },
+
+    methods: {
+
+      getRequestList() {
+        this.$axios.get('/api/company/customer-requests', {params: this.requestBody, headers: {}})
+            .then((res) => {
+                this.items = res.data;
+            }).catch((err) => {
+                alert(err);
+            })
+      },
+
+      onRowSelected(id) {
+
+        this.requestBody.id = id;
+            this.$router.push({
+                name: 'managingServiceProducts',
+                query: this.requestBody
+        })
+      }
+    }
+}
+</script>
+
+<style>
+#request-info-list {
+  width: 1200px;
+  margin: auto;
+  padding-top: 50px;
+}
+
+.info {
+  margin-left: 14px;
+  margin-right: 30px;
+}
+</style>

--- a/shop/vue-frontend/src/views/company/ManagingProductView.vue
+++ b/shop/vue-frontend/src/views/company/ManagingProductView.vue
@@ -122,7 +122,7 @@
           }
         ],
 
-        serviceRequestId: 1 //todo: 추후 prop으로 받아와서 값 바꿔주어야 함.
+        serviceRequestId: this.$route.query.id
 
       }
     },

--- a/shop/vue-frontend/src/views/customer/ReceivedProductDetailView.vue
+++ b/shop/vue-frontend/src/views/customer/ReceivedProductDetailView.vue
@@ -1,0 +1,155 @@
+<template>
+
+    <div id="request-info-list">
+
+        <b-alert show>전문업체의 제안상품</b-alert>
+
+        <b-card
+          border-variant="light"
+          header="업체 정보"
+          header-bg-variant="light"
+          header-text-variant="dark"
+          align="center"
+          style="margin-top: 7px;"
+        >
+          <b-card-text>
+            <div>{{ serviceProductInfo.company.name }}</div>
+            <div>{{ serviceProductInfo.company.introduction }}</div>
+            <div>tel: {{ serviceProductInfo.company.tel }}</div>
+            <div>주소: {{ serviceProductInfo.company.address }}</div>
+            <div>사업자등록번호: {{ serviceProductInfo.company.businessNumber }}</div>
+
+          </b-card-text>
+        </b-card>
+
+        <b-card
+          border-variant="light"
+          header="상품 제안서"
+          header-bg-variant="light"
+          header-text-variant="dark"
+          align="center"
+          style="margin-top: 7px;"
+        >
+          <b-card-text>
+
+
+            <div class="info-row">
+              {{ serviceProductInfo.name }}
+            </div>
+            <div class="info-row">
+              <span class="info">: {{ serviceProductInfo.outlineDescription }}</span>
+            </div>
+
+            <hr/>
+
+            <div class="info-row">
+              <b-icon icon="calendar-check" scale="2" variant="success"></b-icon>
+              <span class="info">실행일시: {{ serviceProductInfo.executeDate }}</span>
+            </div>
+
+            <div class="info-row">
+              <b-icon icon="coin" scale="2" variant="warning"></b-icon>
+              <span class="info">가격: {{ serviceProductInfo.productPrice }} 원</span>
+            </div>
+
+          </b-card-text>
+        </b-card>
+
+        <b-card
+              v-for="(productOption, id) in serviceProductInfo.productOptions" :key="id"
+              border-variant="warning"
+              header="상품옵션"
+              header-bg-variant="transparent"
+              align="center"
+              style="margin-top: 7px;"
+            >
+              <b-card-text>
+
+                <div class="info-row">
+                  <span class="info">옵션명: {{ productOption.name }} </span>
+                </div>
+
+                <div class="info-row">
+                  <b-icon icon="coin" scale="2" variant="success"></b-icon>
+                  <span class="info">옵션 가격: {{ productOption.optionPrice }} 원</span>
+                </div>
+
+                <!-- <b-form-checkbox
+                  id="checkbox-1"
+                  v-model="status"
+                  name="checkbox-1"
+                  value="purchaseYn"
+                  unchecked-value="purchaseYn"
+                >
+                  I accept the terms and use
+                </b-form-checkbox> -->
+                <input type="checkbox" :id="id" :name="id"> 해당 옵션 구매하기
+              </b-card-text>
+            </b-card>  
+
+        <div class="btn-area">
+          <b-button block variant="primary">해당 상품 주문하기</b-button>
+        </div>
+    </div>
+
+</template>
+
+<script>
+
+export default {
+
+    data() {
+      return {
+        id: this.$route.query.id,
+        serviceProductInfo: {},
+        requestBody: {}
+      }
+    },
+
+    mounted() {
+      this.getRequestList();
+    },
+
+    methods: {
+
+      getRequestList() {
+        this.$axios.get('/api/customer/service-product/' + this.id)
+            .then((res) => {
+                this.serviceProductInfo = res.data;
+            }).catch((err) => {
+                alert(err);
+            })
+      },
+
+      // onRowSelected(id) {
+
+      //   this.requestBody.id = id; //서비스상품id
+      //       this.$router.push({
+      //           name: 'managingServiceProducts',
+      //           query: this.requestBody
+      //   })
+      // }
+    }
+}
+</script>
+
+<style>
+#request-info-list {
+  width: 1200px;
+  margin: auto;
+  padding-top: 50px;
+}
+
+.info {
+  margin-left: 14px;
+  margin-right: 30px;
+}
+
+.info-row {
+  margin-bottom: 15px;
+}
+
+.btn-area {
+  margin-top: 15px;
+}
+</style>

--- a/shop/vue-frontend/src/views/customer/ReceivedProductListView.vue
+++ b/shop/vue-frontend/src/views/customer/ReceivedProductListView.vue
@@ -1,0 +1,81 @@
+<template>
+
+    <div id="request-info-list">
+
+        <b-alert show>내게 제안 온 상품 목록</b-alert>
+
+        <b-card v-for="(item, id) in items" :key="id" bg-variant="white" text-variant="dark">
+        
+        <b-card-text class="mr-auto" >
+
+        <span class="info">{{ item.name }}</span>, 
+        
+        <b-icon icon="coin" scale="2" variant="warning"></b-icon>
+        <span class="info">{{ item.productPrice }} 원</span>
+
+        <b-icon icon="calendar-check" scale="2" variant="info"></b-icon>
+        <span class="info">이행일( {{ item.executeDate }} )</span>
+
+        <b-icon icon="person-circle" scale="2" variant="light"></b-icon>
+        <span class="info">{{ item.companyInfo.name }}</span>
+        
+        <a v-on:click="onRowSelected(`${item.id}`)">
+        <b-button variant="light">상품 보기</b-button>
+        </a>
+        </b-card-text>
+        </b-card>
+    </div>
+
+</template>
+
+<script>
+
+export default {
+
+    data() {
+      return {
+
+        items: [],
+        requestBody: {}
+      }
+    },
+
+    mounted() {
+      this.getReceivedProductList();
+    },
+
+    methods: {
+
+      getReceivedProductList() {
+        this.$axios.get('/api/customer/service-product', {params: this.requestBody, headers: {}})
+            .then((res) => {
+                this.items = res.data;
+            }).catch((err) => {
+                alert(err);
+            })
+      },
+
+      onRowSelected(id) {
+
+        this.requestBody.id = id; //서비스상품id
+            this.$router.push({
+                name: 'receivedProductDetail',
+                query: this.requestBody
+        })
+      }
+    }
+}
+</script>
+
+<style>
+#request-info-list {
+  width: 1200px;
+  margin: auto;
+  padding-top: 50px;
+}
+
+.info {
+  margin-left: 14px;
+  margin-right: 30px;
+}
+</style>


### PR DESCRIPTION
:white_check_mark: Changes

- 상품 구매 프로세스에 필요한 조회 api를 추가하였습니다.
- 업체 측에서 고객의 요청서를 전체 조회하는 api, view를 추가하였습니다.
- 고객 측에서 작성한 요청서에 대한 업체의 상품 정보를 확인할 수 있는 목록 조회 api, 상세정보 조회 api를 추가하였습니다.

<br>

:heavy_plus_sign: Related Details

- 기존의 엔티티 내 어노테이션 중, 양방향 매핑에서 발생하는 문제(이번 이슈는 순환참조)에 대한 어노테이션을 수정하였습니다. 
  (상품 - 상품 옵션 간 관계) 
- 기존에는 상품 엔티티 내, 상품 옵션 컬럼에 대해 `@Jsonignore` 처리를 하는 것으로 하였으나, 이를 수정하였습니다.
- 상품 상세보기 기능의 경우,  `@EntityGraph` 를 이용하여 상품 엔티티와 연관관계에 있는 상품옵션 엔티티도 같이 조회해오도록 하였습니다.
<br>

:pray: Reference
- 양방향 매핑과 이로 인해 일어날 수 있는 부분에 대한 처리 방법 참고 링크
: 1) https://m.blog.naver.com/writer0713/221587351970
- 상품 상세보기 조회 기능을 구현할 때 `queryDSL` or `@EntityGraph` 중 하나를 선택하는 데 참고 링크
: 1) https://velog.io/@nestour95/JPA-fetch-join%EA%B3%BC-distinct
  2) https://cornswrold.tistory.com/486