### PR TITLE
feat: [012-COMPLETION-ORDER] 업체 측의 주문 완료 기능 추가

### DIFF
--- a/shop/.gitignore
+++ b/shop/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+application-private.properties

--- a/shop/build.gradle
+++ b/shop/build.gradle
@@ -18,6 +18,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2021.0.1")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -58,6 +62,15 @@ dependencies {
 
 	//webSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	//feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+	imports{
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/shop/build.gradle
+++ b/shop/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
 	//feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	//httpClient
+	implementation 'org.apache.httpcomponents:httpclient:4.5'
 }
 
 dependencyManagement {

--- a/shop/src/main/java/com/moving/shop/ShopApplication.java
+++ b/shop/src/main/java/com/moving/shop/ShopApplication.java
@@ -2,12 +2,14 @@ package com.moving.shop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableJpaRepositories
+@EnableFeignClients
 public class ShopApplication {
 
 	public static void main(String[] args) {

--- a/shop/src/main/java/com/moving/shop/common/client/sms/SmsMessageForm.java
+++ b/shop/src/main/java/com/moving/shop/common/client/sms/SmsMessageForm.java
@@ -1,0 +1,16 @@
+package com.moving.shop.common.client.sms;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsMessageForm {
+
+  String to;
+  String content;
+}

--- a/shop/src/main/java/com/moving/shop/common/client/sms/SmsRequest.java
+++ b/shop/src/main/java/com/moving/shop/common/client/sms/SmsRequest.java
@@ -1,0 +1,21 @@
+package com.moving.shop.common.client.sms;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsRequest {
+
+  String type;
+  String contentType;
+  String countryCode;
+  String from;
+  String content;
+  List<SmsMessageForm> messages;
+}

--- a/shop/src/main/java/com/moving/shop/common/client/sms/SmsResponse.java
+++ b/shop/src/main/java/com/moving/shop/common/client/sms/SmsResponse.java
@@ -1,0 +1,19 @@
+package com.moving.shop.common.client.sms;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsResponse {
+
+  String requestId;
+  LocalDateTime requestTime;
+  String statusCode;
+  String statusName;
+}

--- a/shop/src/main/java/com/moving/shop/common/exception/type/OrderErrorCode.java
+++ b/shop/src/main/java/com/moving/shop/common/exception/type/OrderErrorCode.java
@@ -11,6 +11,7 @@ public enum OrderErrorCode {
   NOT_VALID_REQUEST_INFO(HttpStatus.BAD_REQUEST, "서비스 요청서 정보가 현재 유효하지 않아서 주문이 불가능합니다. 확인이 필요할 시, 고객센터로 주문 희망 서비스를 알려주세요."),
   ALREADY_TAKE_ORDER(HttpStatus.BAD_REQUEST, "이미 해당 요청서에 대한 주문이 진행 중이기 때문에 중복 주문이 불가합니다."),
   NOT_VALID_PRODUCT_INFO(HttpStatus.BAD_REQUEST, "주문하려는 서비스 상품은 현재 유효하지 않아서 주문할 수 없습니다."),
+  NOT_COMPLETE_ORDER(HttpStatus.BAD_REQUEST, "선택한 주문 서비스는 현재 유효하지 않아서 주문 완료 처리할 수 없습니다."),
   NOT_ENOUGH_CASH(HttpStatus.BAD_REQUEST, "현재 잔액 캐쉬로 서비스 주문이 불가합니다. 캐쉬를 충전해주세요.");
 
   private final HttpStatus httpStatus;

--- a/shop/src/main/java/com/moving/shop/common/service/SmsService.java
+++ b/shop/src/main/java/com/moving/shop/common/service/SmsService.java
@@ -1,0 +1,121 @@
+package com.moving.shop.common.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moving.shop.common.client.sms.SmsMessageForm;
+import com.moving.shop.common.client.sms.SmsRequest;
+import com.moving.shop.common.client.sms.SmsResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+
+  @Value("${naver-cloud-sms.accessKey}")
+  private String accessKey;
+
+  @Value("${naver-cloud-sms.secretKey}")
+  private String secretKey;
+
+  @Value("${naver-cloud-sms.serviceId}")
+  private String serviceId;
+
+  @Value("${naver-cloud-sms.senderPhone}")
+  private String phone;
+
+  public SmsResponse sendSms(SmsMessageForm form)
+      throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+
+    Long time = System.currentTimeMillis();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("x-ncp-apigw-timestamp", time.toString());
+    headers.set("x-ncp-iam-access-key", accessKey);
+    headers.set("x-ncp-apigw-signature-v2", makeSignature(time));
+    log.info("accessKey -> {}", accessKey);
+    log.info("accessKey -> {}", accessKey);
+
+    List<SmsMessageForm> messages = new ArrayList<>();
+    messages.add(form);
+
+    log.info("messages -> {}", messages.get(0));
+
+    SmsRequest request = SmsRequest.builder()
+        .type("SMS")
+        .contentType("COMM")
+        .countryCode("82")
+        .from(phone)
+        .content(form.getContent())
+        .messages(messages)
+        .build();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String body = objectMapper.writeValueAsString(request);
+    HttpEntity<String> httpBody = new HttpEntity<>(body, headers);
+
+    RestTemplate restTemplate = new RestTemplate();
+    restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+    SmsResponse response = restTemplate.postForObject(
+        new URI("https://sens.apigw.ntruss.com/sms/v2/services/" + serviceId + "/messages"),
+        httpBody, SmsResponse.class);
+    log.info("response status code ========>> {}", response.getStatusCode());
+    log.info("response status code ========>> {}", response.getRequestTime());
+
+    return response;
+  }
+
+  public String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+
+    String space = " ";					// one space
+    String newLine = "\n";					// new line
+    String method = "POST";					// method
+    String url = "/sms/v2/services/" + this.serviceId + "/messages";	// url (include query string)
+    String timestamp = String.valueOf(time);			// current timestamp (epoch)
+    String accessKey = this.accessKey;			// access key id (from portal or Sub Account)
+    String secretKey = this.secretKey;
+
+    String message = new StringBuilder()
+        .append(method)
+        .append(space)
+        .append(url)
+        .append(newLine)
+        .append(timestamp)
+        .append(newLine)
+        .append(accessKey)
+        .toString();
+
+    SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(signingKey);
+
+    byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
+    String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+    return encodeBase64String;
+  }
+
+}
+
+

--- a/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
+++ b/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
@@ -31,7 +31,7 @@ public class CompanyOrderController {
 
     String refinedToken = token.substring(TOKEN_PREFIX.length());
     companyOrderService.completeServiceOrder(refinedToken, form);
-    return ResponseEntity.ok("");
+    return ResponseEntity.ok("확인");
   }
 
   @GetMapping

--- a/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
+++ b/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
@@ -1,0 +1,41 @@
+package com.moving.shop.order.controller;
+
+import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_HEADER;
+import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_PREFIX;
+
+import com.moving.shop.order.domain.dto.SubmittedOrders;
+import com.moving.shop.order.service.CompanyOrderService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/company/service-orders")
+public class CompanyOrderController {
+
+  private final CompanyOrderService companyOrderService;
+
+  @PostMapping("/completion")
+  @PreAuthorize("hasAuthority('COMPANY')")
+  public ResponseEntity<?> completeOrder() {
+
+    return ResponseEntity.ok("");
+  }
+
+  @GetMapping
+  @PreAuthorize("hasAuthority('COMPANY')")
+  public ResponseEntity<List<SubmittedOrders>> showSubmittedOrders(@RequestHeader(value = TOKEN_HEADER) String token) {
+
+    String refinedToken = token.substring(TOKEN_PREFIX.length());
+    return ResponseEntity.ok(companyOrderService.findSubmittedOrderProductsByCompanyId(refinedToken));
+  }
+
+
+}

--- a/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
+++ b/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
@@ -3,6 +3,7 @@ package com.moving.shop.order.controller;
 import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_HEADER;
 import static com.moving.shop.common.security.JwtAuthenticationFilter.TOKEN_PREFIX;
 
+import com.moving.shop.order.domain.dto.CompleteOrderForm;
 import com.moving.shop.order.domain.dto.SubmittedOrders;
 import com.moving.shop.order.service.CompanyOrderService;
 import java.util.List;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,8 +26,11 @@ public class CompanyOrderController {
 
   @PostMapping("/completion")
   @PreAuthorize("hasAuthority('COMPANY')")
-  public ResponseEntity<?> completeOrder() {
+  public ResponseEntity<?> completeOrder(@RequestHeader(value = TOKEN_HEADER) String token,
+      @RequestBody CompleteOrderForm form) {
 
+    String refinedToken = token.substring(TOKEN_PREFIX.length());
+    companyOrderService.completeServiceOrder(refinedToken, form);
     return ResponseEntity.ok("");
   }
 

--- a/shop/src/main/java/com/moving/shop/order/domain/dto/CompleteOrderForm.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/dto/CompleteOrderForm.java
@@ -1,0 +1,17 @@
+package com.moving.shop.order.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteOrderForm {
+
+  /* 서비스주문 id */
+  private Long serviceOrderId;
+
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/dto/CustomerInfoByServiceOrder.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/dto/CustomerInfoByServiceOrder.java
@@ -1,0 +1,19 @@
+package com.moving.shop.order.domain.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class CustomerInfoByServiceOrder {
+
+  private Long customerId;
+
+  private String phone;
+
+  @QueryProjection
+  public CustomerInfoByServiceOrder(Long customerId, String phone) {
+    this.customerId = customerId;
+    this.phone = phone;
+  }
+
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/dto/SubmittedOrders.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/dto/SubmittedOrders.java
@@ -1,0 +1,30 @@
+package com.moving.shop.order.domain.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class SubmittedOrders {
+
+  /* 주문_서비스상품 ID */
+  private Long orderProductId;
+
+  /* 서비스상품 주문금액 */
+  private int orderPrice;
+
+  /* 서비스 실행일시 */
+  private LocalDateTime executeDate;
+
+  /* 주문 ID */
+  private Long serviceOrderId;
+
+  @QueryProjection
+  public SubmittedOrders(Long orderProductId, int orderPrice, LocalDateTime executeDate, Long serviceOrderId) {
+    this.orderProductId = orderProductId;
+    this.orderPrice = orderPrice;
+    this.executeDate = executeDate;
+    this.serviceOrderId = serviceOrderId;
+  }
+
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/dto/SubmittedOrders.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/dto/SubmittedOrders.java
@@ -19,12 +19,16 @@ public class SubmittedOrders {
   /* 주문 ID */
   private Long serviceOrderId;
 
+  /* 서비스상품명 */
+  private String serviceProductName;
+
   @QueryProjection
-  public SubmittedOrders(Long orderProductId, int orderPrice, LocalDateTime executeDate, Long serviceOrderId) {
+  public SubmittedOrders(Long orderProductId, int orderPrice, LocalDateTime executeDate, Long serviceOrderId, String serviceProductName) {
     this.orderProductId = orderProductId;
     this.orderPrice = orderPrice;
     this.executeDate = executeDate;
     this.serviceOrderId = serviceOrderId;
+    this.serviceProductName = serviceProductName;
   }
 
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/entity/CompletionOrder.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/entity/CompletionOrder.java
@@ -1,0 +1,43 @@
+package com.moving.shop.order.domain.entity;
+
+import com.moving.shop.common.BaseEntity;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.envers.AuditOverride;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class CompletionOrder extends BaseEntity {
+
+  /* 주문_서비스상품 ID */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "service_order_id")
+  private ServiceOrder serviceOrder;
+
+  private int orderPrice;
+
+  /* 고객 확인 여부 */
+  private boolean customerCheckYn;
+
+  /* 업체 확인 여부 */
+  private boolean companyCheckYn;
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/entity/OrderProduct.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/entity/OrderProduct.java
@@ -1,5 +1,6 @@
 package com.moving.shop.order.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.order.domain.dto.AddOrderProductForm;
 import com.moving.shop.product.domain.entity.ProductOption;
@@ -44,6 +45,7 @@ public class OrderProduct extends BaseEntity {
   private LocalDateTime executeDate;
 
   /* 주문서비스상품옵션 */
+  @JsonManagedReference //양방향 매핑 시 순환참조 방지
   @OneToMany(cascade = CascadeType.ALL) //mappedBy = "orderProduct",
   @JoinColumn(name = "order_product_id")
   private List<OrderProductOption> orderProductOptions = new ArrayList<>();

--- a/shop/src/main/java/com/moving/shop/order/domain/entity/OrderProductOption.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/entity/OrderProductOption.java
@@ -1,5 +1,6 @@
 package com.moving.shop.order.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.order.domain.dto.AddOrderProductOptionForm;
 import com.moving.shop.product.domain.entity.ProductOption;
@@ -30,6 +31,7 @@ public class OrderProductOption extends BaseEntity {
   private Long id;
 
   /* 주문서비스상품 ID */
+  @JsonBackReference //양방향 매핑 시 순환참조 방지
   @ManyToOne
   @JoinColumn(name = "order_product_id")
   private OrderProduct orderProduct;

--- a/shop/src/main/java/com/moving/shop/order/domain/entity/ServiceOrder.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/entity/ServiceOrder.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -40,7 +41,7 @@ public class ServiceOrder extends BaseEntity {
   private LocalDateTime orderDate;
 
   /* 고객 서비스요청서 ID */
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "customer_request_id")
   private CustomerRequest customerRequest;
 

--- a/shop/src/main/java/com/moving/shop/order/domain/entity/ServiceOrder.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/entity/ServiceOrder.java
@@ -3,6 +3,7 @@ package com.moving.shop.order.domain.entity;
 import com.moving.shop.common.BaseEntity;
 import com.moving.shop.customer.domain.entity.CustomerRequest;
 import com.moving.shop.order.domain.type.OrderStatus;
+import java.security.Provider.Service;
 import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -55,5 +56,10 @@ public class ServiceOrder extends BaseEntity {
         .serviceAddress(customerRequest.getServiceAddress())
         .customerRequest(customerRequest)
         .build();
+  }
+
+  //setter 없이 entity update
+  public void completeServiceOrder(OrderStatus orderStatus) {
+    this.orderStatus = orderStatus;
   }
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/CompletionOrderRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/CompletionOrderRepository.java
@@ -1,0 +1,8 @@
+package com.moving.shop.order.domain.repository;
+
+import com.moving.shop.order.domain.entity.CompletionOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompletionOrderRepository extends JpaRepository<CompletionOrder, Long> {
+
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.web.bind.annotation.RequestParam;
 
-public interface OrderProductRepository extends JpaRepository<OrderProduct, Long> {
+public interface OrderProductRepository extends JpaRepository<OrderProduct, Long>, OrderProductRepositoryCustom {
 
   @EntityGraph(attributePaths = {"orderProductOptions"}, type = EntityGraphType.LOAD)
   Optional<OrderProduct> findWithOrderProductOptionByServiceOrder_Id(@RequestParam("service_order_id") Long serviceOrderId);

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepository.java
@@ -1,6 +1,7 @@
 package com.moving.shop.order.domain.repository;
 
 import com.moving.shop.order.domain.entity.OrderProduct;
+import java.lang.StackWalker.Option;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
@@ -11,4 +12,6 @@ public interface OrderProductRepository extends JpaRepository<OrderProduct, Long
 
   @EntityGraph(attributePaths = {"orderProductOptions"}, type = EntityGraphType.LOAD)
   Optional<OrderProduct> findWithOrderProductOptionByServiceOrder_Id(@RequestParam("service_order_id") Long serviceOrderId);
+
+  Optional<OrderProduct> findByServiceOrder_Id(@RequestParam("service_order_id") Long serviceOrderId);
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustom.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.moving.shop.order.domain.repository;
+
+import com.moving.shop.order.domain.dto.SubmittedOrders;
+import java.util.List;
+
+public interface OrderProductRepositoryCustom {
+
+  List<SubmittedOrders> findByCompanyId(Long companyId);
+
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
@@ -35,7 +35,6 @@ public class OrderProductRepositoryCustomImpl implements OrderProductRepositoryC
         .join(orderProduct.serviceOrder, serviceOrder)
         .on(serviceOrder.orderStatus.eq(OrderStatus.valueOf("SUBMIT"))) //where
         .fetch();
-
     return orderProducts;
   }
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
@@ -1,0 +1,40 @@
+package com.moving.shop.order.domain.repository;
+
+import com.moving.shop.order.domain.dto.QSubmittedOrders;
+import com.moving.shop.order.domain.dto.SubmittedOrders;
+import com.moving.shop.order.domain.entity.QOrderProduct;
+import com.moving.shop.order.domain.entity.QServiceOrder;
+import com.moving.shop.order.domain.type.OrderStatus;
+import com.moving.shop.product.domain.entity.QServiceProduct;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderProductRepositoryCustomImpl implements OrderProductRepositoryCustom {
+
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<SubmittedOrders> findByCompanyId(Long companyId) {
+
+    QServiceOrder serviceOrder = QServiceOrder.serviceOrder;
+    QOrderProduct orderProduct = QOrderProduct.orderProduct;
+    QServiceProduct serviceProduct = QServiceProduct.serviceProduct;
+
+    List<SubmittedOrders> orderProducts = jpaQueryFactory
+        .select(new QSubmittedOrders(orderProduct.id, orderProduct.orderPrice, orderProduct.executeDate, orderProduct.serviceOrder.id))
+        .from(orderProduct)
+        .join(orderProduct.serviceProduct, serviceProduct)
+        .on(orderProduct.serviceProduct.company.id.eq(companyId)) //where
+        //.fetchJoin()
+        .join(orderProduct.serviceOrder, serviceOrder)
+        .on(serviceOrder.orderStatus.eq(OrderStatus.valueOf("SUBMIT"))) //where
+        .fetch();
+
+    return orderProducts;
+  }
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
@@ -26,7 +26,8 @@ public class OrderProductRepositoryCustomImpl implements OrderProductRepositoryC
     QServiceProduct serviceProduct = QServiceProduct.serviceProduct;
 
     List<SubmittedOrders> orderProducts = jpaQueryFactory
-        .select(new QSubmittedOrders(orderProduct.id, orderProduct.orderPrice, orderProduct.executeDate, orderProduct.serviceOrder.id))
+        .select(new QSubmittedOrders(orderProduct.id, orderProduct.orderPrice, orderProduct.executeDate, orderProduct.serviceOrder.id,
+            serviceProduct.name))
         .from(orderProduct)
         .join(orderProduct.serviceProduct, serviceProduct)
         .on(orderProduct.serviceProduct.company.id.eq(companyId)) //where

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/OrderProductRepositoryCustomImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OrderProductRepositoryCustomImpl implements OrderProductRepositoryCustom {
 
-
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/ServiceOrderRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/ServiceOrderRepository.java
@@ -3,7 +3,7 @@ package com.moving.shop.order.domain.repository;
 import com.moving.shop.order.domain.entity.ServiceOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ServiceOrderRepository extends JpaRepository<ServiceOrder, Long> {
+public interface ServiceOrderRepository extends JpaRepository<ServiceOrder, Long>, ServiceOrderRepositoryCustom {
 
   boolean existsByCustomerRequestId(Long customerRequestId);
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/ServiceOrderRepositoryCustom.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/ServiceOrderRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.moving.shop.order.domain.repository;
+
+import com.moving.shop.order.domain.dto.CustomerInfoByServiceOrder;
+
+public interface ServiceOrderRepositoryCustom {
+
+  CustomerInfoByServiceOrder getCustomerInfoByServiceOrderId(Long serviceOrderId);
+
+}

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/ServiceOrderRepositoryCustomImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/ServiceOrderRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package com.moving.shop.order.domain.repository;
+
+import com.moving.shop.customer.domain.entity.QCustomer;
+import com.moving.shop.customer.domain.entity.QCustomerRequest;
+import com.moving.shop.order.domain.dto.CustomerInfoByServiceOrder;
+import com.moving.shop.order.domain.dto.QCustomerInfoByServiceOrder;
+import com.moving.shop.order.domain.entity.QServiceOrder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ServiceOrderRepositoryCustomImpl implements ServiceOrderRepositoryCustom{
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public CustomerInfoByServiceOrder getCustomerInfoByServiceOrderId(Long serviceOrderId) {
+
+    QServiceOrder serviceOrder = QServiceOrder.serviceOrder;
+    QCustomerRequest customerRequest = QCustomerRequest.customerRequest;
+    QCustomer customer = QCustomer.customer;
+
+    CustomerInfoByServiceOrder customerInfoByServiceOrder = jpaQueryFactory
+        .select(new QCustomerInfoByServiceOrder(customer.id, customer.phone))
+        .from(serviceOrder)
+        .join(serviceOrder.customerRequest, customerRequest)
+        .join(customerRequest.customer, customer)
+        .on(serviceOrder.id.eq(serviceOrderId))
+        .fetchFirst();
+    return customerInfoByServiceOrder;
+  }
+}

--- a/shop/src/main/java/com/moving/shop/order/service/CompanyOrderService.java
+++ b/shop/src/main/java/com/moving/shop/order/service/CompanyOrderService.java
@@ -1,0 +1,10 @@
+package com.moving.shop.order.service;
+
+import com.moving.shop.order.domain.dto.SubmittedOrders;
+import java.util.List;
+
+public interface CompanyOrderService {
+
+  List<SubmittedOrders> findSubmittedOrderProductsByCompanyId(String refinedToken);
+
+}

--- a/shop/src/main/java/com/moving/shop/order/service/CompanyOrderService.java
+++ b/shop/src/main/java/com/moving/shop/order/service/CompanyOrderService.java
@@ -1,10 +1,13 @@
 package com.moving.shop.order.service;
 
+import com.moving.shop.order.domain.dto.CompleteOrderForm;
 import com.moving.shop.order.domain.dto.SubmittedOrders;
+import com.moving.shop.order.domain.entity.CompletionOrder;
 import java.util.List;
 
 public interface CompanyOrderService {
 
   List<SubmittedOrders> findSubmittedOrderProductsByCompanyId(String refinedToken);
 
+  CompletionOrder completeServiceOrder(String refinedToken, CompleteOrderForm form);
 }

--- a/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
@@ -1,12 +1,20 @@
 package com.moving.shop.order.service.impl;
 
 import com.moving.shop.common.exception.customexception.CompanyException;
+import com.moving.shop.common.exception.customexception.OrderException;
 import com.moving.shop.common.exception.type.CompanyErrorCode;
+import com.moving.shop.common.exception.type.OrderErrorCode;
 import com.moving.shop.common.security.TokenProvider;
 import com.moving.shop.company.domain.entity.Company;
 import com.moving.shop.company.domain.repository.CompanyRepository;
+import com.moving.shop.order.domain.dto.CompleteOrderForm;
 import com.moving.shop.order.domain.dto.SubmittedOrders;
+import com.moving.shop.order.domain.entity.CompletionOrder;
+import com.moving.shop.order.domain.entity.OrderProduct;
+import com.moving.shop.order.domain.entity.ServiceOrder;
+import com.moving.shop.order.domain.repository.CompletionOrderRepository;
 import com.moving.shop.order.domain.repository.OrderProductRepository;
+import com.moving.shop.order.domain.repository.ServiceOrderRepository;
 import com.moving.shop.order.service.CompanyOrderService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +26,8 @@ public class CompanyOrderServiceImpl implements CompanyOrderService {
 
   private final OrderProductRepository orderProductRepository;
   private final CompanyRepository companyRepository;
+  private final CompletionOrderRepository completionOrderRepository;
+  private final ServiceOrderRepository serviceOrderRepository;
   private final TokenProvider tokenProvider;
 
   @Override
@@ -28,5 +38,31 @@ public class CompanyOrderServiceImpl implements CompanyOrderService {
         .orElseThrow(() -> new CompanyException(CompanyErrorCode.NOT_EXIST_COMPANY_MEMBER));
 
     return orderProductRepository.findByCompanyId(company.getId());
+  }
+
+  @Override
+  public CompletionOrder completeServiceOrder(String refinedToken, CompleteOrderForm form) {
+
+    //1. 고객 제외 확인으로 data save
+
+    //order info
+    ServiceOrder serviceOrder = serviceOrderRepository.findById(form.getServiceOrderId())
+            .orElseThrow(() -> new OrderException(OrderErrorCode.NOT_COMPLETE_ORDER));
+
+    //order product info
+    OrderProduct orderProduct = orderProductRepository.findByServiceOrder_Id(form.getServiceOrderId())
+            .orElseThrow(() -> new OrderException(OrderErrorCode.NOT_COMPLETE_ORDER));
+
+    completionOrderRepository.save(CompletionOrder.builder()
+            .serviceOrder(serviceOrder)
+            .companyCheckYn(true)
+            .customerCheckYn(false)
+            .orderPrice(orderProduct.getOrderPrice())
+        .build());
+
+    //2. 해당 고객에게 message 확인 발송
+
+
+    return null;
   }
 }

--- a/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
@@ -1,0 +1,32 @@
+package com.moving.shop.order.service.impl;
+
+import com.moving.shop.common.exception.customexception.CompanyException;
+import com.moving.shop.common.exception.type.CompanyErrorCode;
+import com.moving.shop.common.security.TokenProvider;
+import com.moving.shop.company.domain.entity.Company;
+import com.moving.shop.company.domain.repository.CompanyRepository;
+import com.moving.shop.order.domain.dto.SubmittedOrders;
+import com.moving.shop.order.domain.repository.OrderProductRepository;
+import com.moving.shop.order.service.CompanyOrderService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyOrderServiceImpl implements CompanyOrderService {
+
+  private final OrderProductRepository orderProductRepository;
+  private final CompanyRepository companyRepository;
+  private final TokenProvider tokenProvider;
+
+  @Override
+  public List<SubmittedOrders> findSubmittedOrderProductsByCompanyId(String refinedToken) {
+
+    String email = tokenProvider.getUsername(refinedToken);
+    Company company = companyRepository.findByEmail(email)
+        .orElseThrow(() -> new CompanyException(CompanyErrorCode.NOT_EXIST_COMPANY_MEMBER));
+
+    return orderProductRepository.findByCompanyId(company.getId());
+  }
+}

--- a/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
@@ -11,6 +11,7 @@ import com.moving.shop.common.service.SmsService;
 import com.moving.shop.company.domain.entity.Company;
 import com.moving.shop.company.domain.repository.CompanyRepository;
 import com.moving.shop.order.domain.dto.CompleteOrderForm;
+import com.moving.shop.order.domain.dto.CustomerInfoByServiceOrder;
 import com.moving.shop.order.domain.dto.SubmittedOrders;
 import com.moving.shop.order.domain.entity.CompletionOrder;
 import com.moving.shop.order.domain.entity.OrderProduct;
@@ -55,7 +56,6 @@ public class CompanyOrderServiceImpl implements CompanyOrderService {
   public CompletionOrder completeServiceOrder(String refinedToken, CompleteOrderForm form) {
 
     //1. 고객 제외 확인으로 data save
-
     //order info
     ServiceOrder serviceOrder = serviceOrderRepository.findById(form.getServiceOrderId())
             .orElseThrow(() -> new OrderException(OrderErrorCode.NOT_COMPLETE_ORDER));
@@ -76,11 +76,13 @@ public class CompanyOrderServiceImpl implements CompanyOrderService {
     serviceOrder.completeServiceOrder(OrderStatus.COMPLETE);
 
     //2. 해당 고객에게 message 확인 발송
+    //find customer
+    CustomerInfoByServiceOrder customerInfo = serviceOrderRepository.getCustomerInfoByServiceOrderId(serviceOrder.getId());
 
     try {
       smsService.sendSms(SmsMessageForm.builder()
           .content("[서비스 완료]\n 주문하신 서비스가 완료되었음을 아래 링크를 클릭하여 확인해주세요")
-          .to("01047176208") //customer`s phone
+          .to(customerInfo.getPhone()) //customer`s phone
           .build());
     } catch (JsonProcessingException e) {
       e.printStackTrace();

--- a/shop/src/main/resources/application.properties
+++ b/shop/src/main/resources/application.properties
@@ -2,12 +2,6 @@ server.port = 8081
 
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
-spring.datasource.url=jdbc:mariadb://localhost:3309/movingday_db?characterEncoding=UTF-8&serverTimezone=UTC
-
-spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.username=root
-spring.datasource.password=1
-
 #spring.jpa.database=mysql
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
@@ -20,7 +14,7 @@ logging.level.org.hibernate.type.descriptor.sql = trace
 spring.redis.host=localhost
 spring.redis.port=6379
 
-spring.jwt.secret=ZGF5b25lLXNwcmluZy1ib290LWRpdmlkZW5kLXByb2pkY3QtdHV0b3JpYWwtand0LXNlY3JldC1rZXk=
-
 uploadPath= file:///C:/movingday-upload/
 companyImgLocation= C:/movingday-upload/company
+
+spring.profiles.include=private

--- a/shop/src/test/java/com/moving/shop/order/service/CompanyOrderServiceTest.java
+++ b/shop/src/test/java/com/moving/shop/order/service/CompanyOrderServiceTest.java
@@ -1,0 +1,261 @@
+package com.moving.shop.order.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.moving.shop.common.exception.customexception.CustomerException;
+import com.moving.shop.common.exception.type.CustomerErrorCode;
+import com.moving.shop.common.security.TokenProvider;
+import com.moving.shop.company.application.CompanySignInApplication;
+import com.moving.shop.company.domain.dto.CompanySignInForm;
+import com.moving.shop.company.domain.dto.CompanySignUpForm;
+import com.moving.shop.company.service.CompanySignUpService;
+import com.moving.shop.customer.application.CustomerSignInApplication;
+import com.moving.shop.customer.application.CustomerSignUpApplication;
+import com.moving.shop.customer.domain.dto.CustomerRequestForm;
+import com.moving.shop.customer.domain.dto.SignInForm;
+import com.moving.shop.customer.domain.dto.SignUpForm;
+import com.moving.shop.customer.domain.entity.Customer;
+import com.moving.shop.customer.domain.entity.CustomerRequest;
+import com.moving.shop.customer.domain.repository.CustomerRepository;
+import com.moving.shop.customer.domain.repository.CustomerRequestRepository;
+import com.moving.shop.customer.service.CustomerRequestService;
+import com.moving.shop.order.domain.dto.AddOrderProductForm;
+import com.moving.shop.order.domain.dto.AddOrderProductOptionForm;
+import com.moving.shop.order.domain.dto.CompleteOrderForm;
+import com.moving.shop.order.domain.entity.CompletionOrder;
+import com.moving.shop.order.domain.entity.ServiceOrder;
+import com.moving.shop.order.domain.repository.OrderProductOptionRepository;
+import com.moving.shop.order.domain.repository.OrderProductRepository;
+import com.moving.shop.order.domain.type.OrderStatus;
+import com.moving.shop.product.domain.dto.AddProductOptionForm;
+import com.moving.shop.product.domain.dto.AddServiceProductForm;
+import com.moving.shop.product.domain.entity.ServiceProduct;
+import com.moving.shop.product.service.CompanyProductService;
+import com.moving.shop.product.service.CustomerProductService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+@SpringBootTest
+class CompanyOrderServiceTest {
+
+  @Autowired
+  private CompanyOrderService companyOrderService;
+
+  @Autowired
+  private OrderProductOptionRepository orderProductOptionRepository;
+
+  @Autowired
+  private OrderProductRepository orderProductRepository;
+
+  @Autowired
+  private CustomerOrderService customerOrderService;
+
+  @Autowired
+  private CustomerRepository customerRepository;
+
+  @Autowired
+  private CustomerRequestRepository customerRequestRepository;
+
+  @Autowired
+  private CustomerProductService customerProductService;
+
+  @Autowired
+  private CompanyProductService companyProductService;
+
+  @Autowired
+  private CompanySignInApplication companySignInApplication;
+
+  @Autowired
+  private CompanySignUpService companySignUpService;
+
+  @Autowired
+  private CustomerSignUpApplication customerSignUpApplication;
+
+  @Autowired
+  private CustomerSignInApplication customerSignInApplication;
+
+  @Autowired
+  private CustomerRequestService customerRequestService;
+
+  @Autowired
+  private TokenProvider tokenProvider;
+
+  @Test
+  void COMPLETE_ORDER_SUCCESS() {
+
+    //given
+    ServiceProduct serviceProduct = addServiceProduct();
+
+    //when
+    String customersJwt = loginCustomer();
+    AddOrderProductForm orderProductForm = makeOrderFormWithAllOptions(customersJwt);
+    ServiceOrder serviceOrder = customerOrderService.createOrder(orderProductForm);
+
+    // 업체측에서 주문 완료 확인 data 생성하기
+    String companiesJwt = loginCompany();
+    CompletionOrder completionOrder = companyOrderService.completeServiceOrder(companiesJwt,
+        CompleteOrderForm.builder().serviceOrderId(serviceOrder.getId()).build());
+
+    //then
+    assertEquals(completionOrder.getServiceOrder().getId(), serviceOrder.getId());
+    assertEquals(completionOrder.getServiceOrder().getOrderStatus(), OrderStatus.COMPLETE);
+    assertEquals(completionOrder.isCompanyCheckYn(), true);
+    assertEquals(completionOrder.isCustomerCheckYn(), false);
+  }
+
+  private AddOrderProductForm makeOrderFormWithAllOptions(String customersJwt) {
+
+    //고객 앞으로 온 서비스 상품 정보를 토대로 주문 form 생성
+    List<ServiceProduct> serviceProductsForRequest = customerProductService.findByCustomerId(customersJwt);
+    //서비스 상품 정보 내의 모든 옵션 포함하여 주문 form 생성
+    List<AddOrderProductOptionForm> options = new ArrayList<>();
+    for (int i=0; i<serviceProductsForRequest.get(0).getProductOptions().size(); i++) {
+
+      AddOrderProductOptionForm optionForm = AddOrderProductOptionForm.builder()
+          .productOptionId(serviceProductsForRequest.get(0).getProductOptions().get(i).getId())
+          .optionPrice(serviceProductsForRequest.get(0).getProductOptions().get(i).getOptionPrice())
+          .build();
+      options.add(optionForm);
+    }
+
+    AddOrderProductForm orderForm = AddOrderProductForm.builder()
+        .customerRequestId(serviceProductsForRequest.get(0).getCustomerRequest().getId())
+        .serviceProductId(serviceProductsForRequest.get(0).getId())
+        .productPrice(serviceProductsForRequest.get(0).getProductPrice())
+        .addOrderProductOptionForms(options)
+        .build();
+    return orderForm;
+  }
+
+  private ServiceProduct addServiceProduct() {
+
+    String companysJwt = makeCompanysJwt();
+    CustomerRequest customerRequest = makeCustomerRequest();
+
+    List<AddProductOptionForm> addProductOptionForms = makeProductOptionForms();
+    AddServiceProductForm addServiceProductForm = AddServiceProductForm.builder()
+        .executeDate(LocalDateTime.now().plusMonths(3))
+        .name("테스트상품")
+        .productOptions(addProductOptionForms)
+        .outlineDescription("테스트용으로 등록하는 상품입니다.")
+        .productPrice(150000)
+        .serviceRequestId(customerRequest.getId())
+        .build();
+    return companyProductService.addServiceProduct(companysJwt, addServiceProductForm);
+  }
+
+  private CustomerRequest makeCustomerRequest() {
+
+    //given
+    String customersJwt = makeCustomersJwt();
+
+    CustomerRequestForm form = CustomerRequestForm.builder()
+        .serviceAddress("경기 가평")
+        .desiredDate(LocalDate.now().plusMonths(3))
+        .detailRequest("test 요구사항입니다.")
+        .placeArea(23)
+        .serviceCategory("cleaning")
+        .placeShape("house")
+        .build();
+
+    //when
+    Customer customer = customerRepository.findByEmail(tokenProvider.getUsername(customersJwt))
+        .orElseThrow(() -> new CustomerException(CustomerErrorCode.NOT_EXIST_MEMBER));
+
+    CustomerRequest customerRequest = CustomerRequest.builder()
+        .customer(customer)
+        .serviceAddress(form.getServiceAddress())
+        .desiredDate(form.getDesiredDate())
+        .detailRequest(form.getDetailRequest())
+        .placeArea(form.getPlaceArea())
+        .serviceCategory(form.getServiceCategoryType())
+        .placeShape(form.getPlaceShapeType())
+        .build();
+    return customerRequestRepository.save(customerRequest);
+  }
+
+  private List<AddProductOptionForm> makeProductOptionForms() {
+
+    List<AddProductOptionForm> addProductOptionForms = new ArrayList<>();
+    AddProductOptionForm addProductOption1 = AddProductOptionForm.builder().name("상품옵션1")
+        .optionPrice(500).build();
+    AddProductOptionForm addProductOption2 = AddProductOptionForm.builder().name("상품옵션2")
+        .optionPrice(1000).build();
+    addProductOptionForms.add(addProductOption1);
+    addProductOptionForms.add(addProductOption2);
+    return addProductOptionForms;
+  }
+
+  private String makeCompanysJwt() {
+
+    //given
+    CompanySignUpForm form = CompanySignUpForm.builder()
+        .serviceCategory("cleaning")
+        .email("company@google.com")
+        .password("1111")
+        .address("서울시 영등포구")
+        .addressDetail("가평읍")
+        .zipcode("119662")
+        .tel("01022223333")
+        .introduction("test용 업체 회원가입")
+        .businessNumber("1123345565")
+        .build();
+    companySignUpService.signUp(form);
+
+    CompanySignInForm loginForm = CompanySignInForm.builder()
+        .email("company@google.com")
+        .password("1111")
+        .build();
+    String jwt = companySignInApplication.generateToken(loginForm);
+    return jwt;
+  }
+
+  private String loginCompany() {
+
+    CompanySignInForm signInForm = CompanySignInForm
+        .builder()
+        .email("company@google.com")
+        .password("1111")
+        .build();
+    return companySignInApplication.generateToken(signInForm);
+  }
+
+  private String makeCustomersJwt() {
+
+    //given
+    SignUpForm form = SignUpForm.builder()
+        .email("testtest0101@naver.com")
+        .name("testuser")
+        .password("1122")
+        .phone("01012345667").build();
+    customerSignUpApplication.customerSignUp(form);
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest0101@naver.com")
+        .password("1122")
+        .build();
+    String jwt = customerSignInApplication.generateToken(signInForm);
+
+    return jwt;
+  }
+
+  private String loginCustomer() {
+
+    SignInForm signInForm = SignInForm.builder()
+        .email("testtest0101@naver.com")
+        .password("1122")
+        .build();
+    return customerSignInApplication.generateToken(signInForm);
+  }
+
+}

--- a/shop/vue-frontend/src/components/common/HeaderVue.vue
+++ b/shop/vue-frontend/src/components/common/HeaderVue.vue
@@ -44,10 +44,12 @@
 
       <!-- Right aligned nav items -->
       <b-navbar-nav class="ml-auto">
-        <b-nav-form>
+
+
+        <!-- <b-nav-form>
           <b-form-input size="sm" class="mr-sm-2" placeholder="Search"></b-form-input>
           <b-button size="sm" class="my-2 my-sm-0" type="submit">Search</b-button>
-        </b-nav-form>
+        </b-nav-form> -->
 
         <b-nav-item-dropdown v-if="this.$store.state.userStore.isLogin" right>
           <!-- Using 'button-content' slot -->


### PR DESCRIPTION
:white_check_mark: Changes

- 고객이 업체의 상품을 주문한 후, 업체가 해당 주문에 대해 완료 처리를 하도록 하는 기능을 추가하였습니다.

<br>

:heavy_plus_sign: Related Details

- 여러 table의 join은 queryDSL을 통해서 생성한 쿼리를 dto에 담아서 반환하는 것으로 구현하였습니다.
: dto를 반환하는 것으로 구현하지 않을 경우, 양방향 매핑한 객체들이 있어서 순환참조로 인한 에러가 발생하기 때문에 
`@QueryProjection` 을 이용해서 dto를 반환하는 방법으로 하였습니다.
<br>

:pray: Reference
- JPA 순환참조 관련 에러 해결 시 참고링크
: https://m.blog.naver.com/writer0713/221587351970

- queryDSL DTO 조회 방법 참고링크
: https://wildeveloperetrain.tistory.com/94