### PR TITLE
feat: [012-COMPLETION-ORDER] 고객 회원의 주문 완료 기능

### DIFF
--- a/shop/src/main/java/com/moving/shop/common/exception/type/OrderErrorCode.java
+++ b/shop/src/main/java/com/moving/shop/common/exception/type/OrderErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum OrderErrorCode {
 
   NOT_VALID_REQUEST_INFO(HttpStatus.BAD_REQUEST, "서비스 요청서 정보가 현재 유효하지 않아서 주문이 불가능합니다. 확인이 필요할 시, 고객센터로 주문 희망 서비스를 알려주세요."),
+  NOT_MATCHED_ORDER_INFO(HttpStatus.BAD_REQUEST, "일치하지 않는 주문 정보가 있어 주문 완료 확인 처리가 불가합니다."),
   ALREADY_TAKE_ORDER(HttpStatus.BAD_REQUEST, "이미 해당 요청서에 대한 주문이 진행 중이기 때문에 중복 주문이 불가합니다."),
   NOT_VALID_PRODUCT_INFO(HttpStatus.BAD_REQUEST, "주문하려는 서비스 상품은 현재 유효하지 않아서 주문할 수 없습니다."),
   NOT_COMPLETE_ORDER(HttpStatus.BAD_REQUEST, "선택한 주문 서비스는 현재 유효하지 않아서 주문 완료 처리할 수 없습니다."),

--- a/shop/src/main/java/com/moving/shop/order/application/OrderApplication.java
+++ b/shop/src/main/java/com/moving/shop/order/application/OrderApplication.java
@@ -53,4 +53,8 @@ public class OrderApplication {
     return serviceOrder;
   }
 
+  public void customerOrderCompletionVerify(String code, Long completionOrderId) {
+    customerOrderService.orderCompletionVerify(code, completionOrderId);
+  }
+
 }

--- a/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
+++ b/shop/src/main/java/com/moving/shop/order/controller/CompanyOrderController.java
@@ -31,7 +31,7 @@ public class CompanyOrderController {
 
     String refinedToken = token.substring(TOKEN_PREFIX.length());
     companyOrderService.completeServiceOrder(refinedToken, form);
-    return ResponseEntity.ok("확인");
+    return ResponseEntity.ok("업체회원님의 주문완료 확인을 완료하였습니다. 상품 주문 고객님의 문자 알림 확인 시, 주문완료 확인이 정상적으로 처리됩니다.");
   }
 
   @GetMapping

--- a/shop/src/main/java/com/moving/shop/order/controller/CustomerOrderController.java
+++ b/shop/src/main/java/com/moving/shop/order/controller/CustomerOrderController.java
@@ -8,6 +8,7 @@ import com.moving.shop.order.domain.dto.AddOrderProductForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -32,4 +33,11 @@ public class CustomerOrderController {
     return ResponseEntity.ok("");
   }
 
+  @GetMapping("/completion/verify")
+  @PreAuthorize("hasAuthority('CUSTOMER')")
+  public ResponseEntity<?> customerVerifyOrderCompletion(String code, Long completionOrderId) {
+    
+    orderApplication.customerOrderCompletionVerify(code, completionOrderId);
+    return ResponseEntity.ok("고객님의 주문 완료를 확인하였습니다.");
+  }
 }

--- a/shop/src/main/java/com/moving/shop/order/controller/CustomerOrderController.java
+++ b/shop/src/main/java/com/moving/shop/order/controller/CustomerOrderController.java
@@ -36,7 +36,7 @@ public class CustomerOrderController {
   @GetMapping("/completion/verify")
   @PreAuthorize("hasAuthority('CUSTOMER')")
   public ResponseEntity<?> customerVerifyOrderCompletion(String code, Long completionOrderId) {
-    
+
     orderApplication.customerOrderCompletionVerify(code, completionOrderId);
     return ResponseEntity.ok("고객님의 주문 완료를 확인하였습니다.");
   }

--- a/shop/src/main/java/com/moving/shop/order/domain/entity/CompletionOrder.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/entity/CompletionOrder.java
@@ -40,4 +40,11 @@ public class CompletionOrder extends BaseEntity {
 
   /* 업체 확인 여부 */
   private boolean companyCheckYn;
+
+  /* 주문완료 고객 확인 시 사용 verifycationCode */
+  private String verificationCode;
+
+  public void customersVerify() {
+    this.customerCheckYn = true;
+  }
 }

--- a/shop/src/main/java/com/moving/shop/order/domain/repository/CompletionOrderRepository.java
+++ b/shop/src/main/java/com/moving/shop/order/domain/repository/CompletionOrderRepository.java
@@ -1,8 +1,10 @@
 package com.moving.shop.order.domain.repository;
 
 import com.moving.shop.order.domain.entity.CompletionOrder;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CompletionOrderRepository extends JpaRepository<CompletionOrder, Long> {
 
+  Optional<CompletionOrder> findByIdAndVerificationCode(Long completionOrderId, String code);
 }

--- a/shop/src/main/java/com/moving/shop/order/service/CustomerOrderService.java
+++ b/shop/src/main/java/com/moving/shop/order/service/CustomerOrderService.java
@@ -7,4 +7,5 @@ public interface CustomerOrderService {
 
   ServiceOrder createOrder(AddOrderProductForm form);
 
+  void orderCompletionVerify(String code, Long completionOrderId);
 }

--- a/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/service/impl/CompanyOrderServiceImpl.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -70,6 +71,7 @@ public class CompanyOrderServiceImpl implements CompanyOrderService {
             .companyCheckYn(true)
             .customerCheckYn(false)
             .orderPrice(orderProduct.getOrderPrice())
+            .verificationCode(UUID.randomUUID().toString())
         .build());
 
     //service order status update
@@ -80,8 +82,14 @@ public class CompanyOrderServiceImpl implements CompanyOrderService {
     CustomerInfoByServiceOrder customerInfo = serviceOrderRepository.getCustomerInfoByServiceOrderId(serviceOrder.getId());
 
     try {
-      smsService.sendSms(SmsMessageForm.builder()
-          .content("[서비스 완료]\n 주문하신 서비스가 완료되었음을 아래 링크를 클릭하여 확인해주세요")
+      smsService.sendSms(
+          SmsMessageForm.builder()
+          .content(
+              "[서비스 완료]\n 주문하신 서비스가 완료되었음을 아래 링크를 클릭하여 확인해주세요\n" +
+              "주문완료 확인 링크>> http:http://localhost:8081/api/customer/order/completion/verify" +
+              "?" + "code=" + completionOrder.getVerificationCode() +
+              "&id=" + completionOrder.getId()
+          )
           .to(customerInfo.getPhone()) //customer`s phone
           .build());
     } catch (JsonProcessingException e) {

--- a/shop/src/main/java/com/moving/shop/order/service/impl/CustomerOrderServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/order/service/impl/CustomerOrderServiceImpl.java
@@ -34,6 +34,7 @@ public class CustomerOrderServiceImpl implements CustomerOrderService {
   private final CustomerRequestRepository customerRequestRepository;
   private final ProductOptionRepository productOptionRepository;
 
+  @Transactional
   @Override
   public ServiceOrder createOrder(AddOrderProductForm form) {
 
@@ -59,7 +60,7 @@ public class CustomerOrderServiceImpl implements CustomerOrderService {
     ServiceOrder serviceOrder = serviceOrderRepository.save(ServiceOrder.createServiceOrder(customerRequest));
 
     // 2-6. save orderProduct
-    ServiceProduct.buyServiceProduct(serviceProduct);
+    serviceProduct.buyServiceProduct(serviceProduct); //set 사용하지 않는 방식으로 수정
     OrderProduct orderProduct = orderProductRepository.save(
         OrderProduct.of(serviceOrder, serviceProduct, form, wishOptions));
 

--- a/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/entity/ServiceProduct.java
@@ -88,8 +88,8 @@ public class ServiceProduct extends BaseEntity {
         .build();
   }
 
-  public static void buyServiceProduct(ServiceProduct serviceProduct) {
-    serviceProduct.setPurchaseYn(true);
+  public void buyServiceProduct(ServiceProduct serviceProduct) {
+    this.purchaseYn = true;
   }
 
 }


### PR DESCRIPTION
:white_check_mark: Changes

- (주문 완료에 대해서 서비스 업체가 고객 쪽으로 주문 완료 확인 요청 알람을 보낼 때)
이후, 문자발송을 통해서 온 주소 링크를 고객이 누를 시, 고객의 주문 완료 확인이 되는 기능을 추가하였습니다.

<br>

:heavy_plus_sign: Related Details

- 해당 내용이 정상 동작하는지 test code를 통해서 확인하였습니다.
- 추가적으로 다른 기능(고객의 상품 주문 시, 서비스상품의 주문 여부 필드 값 변경 코드 라인)에 대해서 set 메서드를 사용하지 않고, 해당 객체 내에서 this를 통해서 필드값을 변경하는 방식으로 값의 update가 이뤄지도록 하였습니다.

<br>

:pray: Reference
- 도메인 모델에서의 set 사용에 대해 대안 방법 참고 링크
( http://blog.eomdev.com/ddd/2019/08/20/ddd-setter.html )
