### PR TITLE
feat: [014-PRODUCT-UPDATE] 업체의 상품 삭제 기능 추가

### DIFF
--- a/shop/src/main/java/com/moving/shop/common/exception/type/CompanyErrorCode.java
+++ b/shop/src/main/java/com/moving/shop/common/exception/type/CompanyErrorCode.java
@@ -14,6 +14,7 @@ public enum CompanyErrorCode {
   ALREADY_ORDERED_PRODUCT(HttpStatus.BAD_REQUEST, "상품 변경은 고객 회원님의 주문이 진행된 상태 이전에만 가능한 서비스입니다."),
   SERVICE_PRODUCT_NOT_EXIST(HttpStatus.BAD_REQUEST, "변경하려는 상품에 대한 정보가 존재하지 않습니다. 새로운 상품을 등록해주세요."),
   PRODUCT_OPTION_NOT_EXIST(HttpStatus.BAD_REQUEST, "변경하려는 상품 옵션에 대한 정보가 존재하지 않습니다. 새로운 상품을 등록해주세요."),
+  CHAT_ROOM_INFO_NOT_EXIST(HttpStatus.BAD_REQUEST, "찾으려는 상품에 대한 상담방 정보가 존재하지 않습니다. 확인 혹은 고객센터에 문의해주세요."),
   EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "해당 이메일을 가진 회원이 이미 존재합니다. 다른 이메일을 사용해주세요.");
 
   private final HttpStatus httpStatus;

--- a/shop/src/main/java/com/moving/shop/product/controller/CompanyProductController.java
+++ b/shop/src/main/java/com/moving/shop/product/controller/CompanyProductController.java
@@ -53,12 +53,12 @@ public class CompanyProductController {
   @DeleteMapping("/{serviceProductId}")
   @PreAuthorize("hasAuthority('COMPANY')")
   @ApiOperation(value="업체 회원의 서비스 상품 삭제 API", notes = "로그인한 업체 회원이 고객의 요청서에 대한 서비스 상품(주문이 들어가기 전의 경우)을 삭제할 때 사용합니다.")
-  public ResponseEntity<?> deleteServiceProduct(@RequestHeader(value = TOKEN_HEADER) String token,
+  public ResponseEntity<Void> deleteServiceProduct(@RequestHeader(value = TOKEN_HEADER) String token,
       @PathVariable("serviceProductId") Long serviceProductId) {
 
     String refinedToken = token.substring(TOKEN_PREFIX.length());
     companyProductService.deleteServiceProduct(refinedToken, serviceProductId);
-    return ResponseEntity.ok("");
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/shop/src/main/java/com/moving/shop/product/controller/CompanyProductController.java
+++ b/shop/src/main/java/com/moving/shop/product/controller/CompanyProductController.java
@@ -12,6 +12,8 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,6 +48,17 @@ public class CompanyProductController {
     String refinedToken = token.substring(TOKEN_PREFIX.length());
     return ResponseEntity.ok(
         ServiceProductResponse.from(companyProductService.updateServiceProduct(refinedToken, form)));
+  }
+
+  @DeleteMapping("/{serviceProductId}")
+  @PreAuthorize("hasAuthority('COMPANY')")
+  @ApiOperation(value="업체 회원의 서비스 상품 삭제 API", notes = "로그인한 업체 회원이 고객의 요청서에 대한 서비스 상품(주문이 들어가기 전의 경우)을 삭제할 때 사용합니다.")
+  public ResponseEntity<?> deleteServiceProduct(@RequestHeader(value = TOKEN_HEADER) String token,
+      @PathVariable("serviceProductId") Long serviceProductId) {
+
+    String refinedToken = token.substring(TOKEN_PREFIX.length());
+    companyProductService.deleteServiceProduct(refinedToken, serviceProductId);
+    return ResponseEntity.ok("");
   }
 
 }

--- a/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepository.java
+++ b/shop/src/main/java/com/moving/shop/product/domain/repository/ServiceProductRepository.java
@@ -10,4 +10,6 @@ public interface ServiceProductRepository extends JpaRepository<ServiceProduct, 
 
   @EntityGraph(attributePaths = {"productOptions"}, type = EntityGraphType.LOAD)
   Optional<ServiceProduct> findWithProductOptionsById(Long id);
+
+  boolean existsById(Long id);
 }

--- a/shop/src/main/java/com/moving/shop/product/service/CompanyProductService.java
+++ b/shop/src/main/java/com/moving/shop/product/service/CompanyProductService.java
@@ -9,4 +9,6 @@ public interface CompanyProductService {
   ServiceProduct addServiceProduct(String refinedToken, AddServiceProductForm form);
 
   ServiceProduct updateServiceProduct(String refinedToken, UpdateServiceProductForm form);
+
+  void deleteServiceProduct(String refinedToken, Long serviceProductId);
 }

--- a/shop/src/main/java/com/moving/shop/product/service/impl/CompanyProductServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/service/impl/CompanyProductServiceImpl.java
@@ -87,4 +87,26 @@ public class CompanyProductServiceImpl implements CompanyProductService {
     //상품 정보 update
     return serviceProduct.updateServiceProduct(form);
   }
+
+  @Transactional
+  @Override
+  public void deleteServiceProduct(String refinedToken, Long serviceProductId) {
+
+    //data check
+    String email = tokenProvider.getUsername(refinedToken);
+    if (!companyRepository.existsByEmail(email)) {
+      throw new CompanyException(CompanyErrorCode.NOT_EXIST_COMPANY_MEMBER);
+    }
+
+    ChatRoom chatRoom = chatRoomRepository.findByServiceProduct_Id(serviceProductId)
+        .orElseThrow(() -> new CompanyException(CompanyErrorCode.CHAT_ROOM_INFO_NOT_EXIST));
+
+    //chat room delete
+    chatRoomRepository.deleteById(chatRoom.getId());
+
+    //redis chat room delete
+
+    //product and option delete
+    serviceProductRepository.deleteById(serviceProductId);
+  }
 }

--- a/shop/src/main/java/com/moving/shop/product/service/impl/CompanyProductServiceImpl.java
+++ b/shop/src/main/java/com/moving/shop/product/service/impl/CompanyProductServiceImpl.java
@@ -105,6 +105,7 @@ public class CompanyProductServiceImpl implements CompanyProductService {
     chatRoomRepository.deleteById(chatRoom.getId());
 
     //redis chat room delete
+    redisChatRoomRepository.deleteChatRoom(chatRoom.getId());
 
     //product and option delete
     serviceProductRepository.deleteById(serviceProductId);

--- a/shop/src/main/java/com/moving/shop/servicechat/domain/redis/RedisChatRoomRepository.java
+++ b/shop/src/main/java/com/moving/shop/servicechat/domain/redis/RedisChatRoomRepository.java
@@ -67,4 +67,8 @@ public class RedisChatRoomRepository {
     return topicMap.get(roomId);
   }
 
+  public void deleteChatRoom(Long key) {
+    redisTemplate.delete(key.toString());
+  }
+
 }

--- a/shop/src/main/java/com/moving/shop/servicechat/domain/repository/ChatRoomRepository.java
+++ b/shop/src/main/java/com/moving/shop/servicechat/domain/repository/ChatRoomRepository.java
@@ -2,7 +2,9 @@ package com.moving.shop.servicechat.domain.repository;
 
 import com.moving.shop.servicechat.domain.entity.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
@@ -11,4 +13,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   List<ChatRoom> findAllByCustomerId(Long customerId);
 
   List<ChatRoom> findAllByCompanyId(Long companyId);
+
+  Optional<ChatRoom> findByServiceProduct_Id(@RequestParam("service_product_id") Long serviceProductId);
 }

--- a/shop/src/main/java/com/moving/shop/servicechat/domain/repository/ChatRoomRepository.java
+++ b/shop/src/main/java/com/moving/shop/servicechat/domain/repository/ChatRoomRepository.java
@@ -15,4 +15,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   List<ChatRoom> findAllByCompanyId(Long companyId);
 
   Optional<ChatRoom> findByServiceProduct_Id(@RequestParam("service_product_id") Long serviceProductId);
+
+  boolean existsById(Long id);
 }


### PR DESCRIPTION
:white_check_mark: Changes

- 업체 측에서 등록한 상품을 삭제할 수 있는 기능을 추가하였습니다.
- 고객이 해당 상품에 대한 다른 행위 (주문 혹은 주문 완료 이후의 상태)를 하지 않았을 때에만 삭제가 가능합니다.

<br>

:heavy_plus_sign: Related Details

- 업체 측에서 상품 삭제 시, 함께 삭제되어야 할 부분은 test code 작성 시, exists 문을 통해서 삭제 여부를 확인하였습니다.
- 상품, 상품에 대한 상품옵션, 상품에 대한 채팅방 정보가 함께 삭제되도록 하였습니다.

<br>

:pray: Reference
